### PR TITLE
Add one-shot-deployment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,7 +83,8 @@ username = user \n\
 password = password \n\
 [cega.broker] \n\
 host = cega_mq \n\
-username = test " >> conf.ini
+username = test \n\
+password = password" >> conf.ini
 
 # Populate env-settings
 WORKDIR .env.d
@@ -103,4 +104,4 @@ CEGA_USERS=./cega_users" >> .env
 
 RUN mkdir ../configuration
 
-CMD echo "password = ${password}" >> conf.ini && cp -r . ../configuration
+CMD cp -r . ../configuration

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,106 @@
+FROM ubuntu:17.04
+
+MAINTAINER https://github.com/dtitov
+
+# Install required tools 
+RUN apt update && apt install wget curl nano mc git openssl docker.io -yq --no-install-recommends
+
+# Install GPG 2.2
+WORKDIR gpg_installation
+RUN apt update && apt -y install libgnutls-dev bzip2 make gettext texinfo gnutls-bin libgnutls28-dev build-essential libbz2-dev zlib1g-dev libncurses5-dev libsqlite3-dev libldap2-dev || apt -y install libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential libbz2-dev zlib1g-dev libncurses5-dev libsqlite3-dev libldap2-dev
+RUN wget -c https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.gz && \
+wget -c https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.gz && \
+wget -c https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.3.tar.bz2 && \
+wget -c https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.3.5.tar.bz2 && \
+wget -c https://www.gnupg.org/ftp/gcrypt/npth/npth-1.5.tar.bz2 && \
+wget -c https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.0.0.tar.bz2 && \
+wget -c https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.1.tar.bz2 && \
+tar -xzf libgpg-error-1.27.tar.gz && \
+tar -xzf libgcrypt-1.8.1.tar.gz && \
+tar -xjf libassuan-2.4.3.tar.bz2 && \
+tar -xjf libksba-1.3.5.tar.bz2 && \
+tar -xjf npth-1.5.tar.bz2 && \
+tar -xjf pinentry-1.0.0.tar.bz2 && \
+tar -xjf gnupg-2.2.1.tar.bz2 && \
+cd libgpg-error-1.27/ && ./configure && make && make install && cd ../ && \
+cd libgcrypt-1.8.1 && ./configure && make && make install && cd ../ && \
+cd libassuan-2.4.3 && ./configure && make && make install && cd ../ && \
+cd libksba-1.3.5 && ./configure && make && make install && cd ../ && \
+cd npth-1.5 && ./configure && make && make install && cd ../ && \
+cd pinentry-1.0.0 && ./configure --enable-pinentry-curses --disable-pinentry-qt4 && \
+make && make install && cd ../ && \
+cd gnupg-2.2.1 && ./configure && make && make install && \
+echo "/usr/local/lib" > /etc/ld.so.conf.d/gpg2.conf && ldconfig -v
+
+# Generate GPG stuff
+WORKDIR ../lega_setup/gpg_home
+RUN echo "%echo Generating a basic OpenPGP key \n\
+Key-Type: RSA \n\
+Key-Length: 4096 \n\
+Name-Real: EGA Sweden \n\
+Name-Comment: @NBIS \n\
+Name-Email: ega@nbis.se \n\
+Expire-Date: 0 \n\
+Passphrase: passphrase \n\
+# Do a commit here, so that we can later print "done" :-) \n\
+%commit \n\
+%echo done" >> gen_key && gpg --homedir . --batch --generate-key gen_key
+
+
+# Generate RSA stuff
+WORKDIR ../rsa_home
+RUN openssl genpkey -algorithm RSA -out rsa.sec -pkeyopt rsa_keygen_bits:2048 && openssl rsa -pubout -in rsa.sec -out rsa.pub
+
+# Generate SSL stuff
+WORKDIR ../ssl_home
+RUN openssl req -x509 -newkey rsa:2048 -keyout ssl.key -nodes -out ssl.cert -sha256 -days 1000 -subj "/C=NO/ST=Oslo/L=Oslo/O=UiO/OU=IFI/CN=test"
+
+# Generate MD5 stuff
+WORKDIR ../md5_home
+RUN echo "Algorithm: MD5\nSalt: xyz\nPassword: hello\n$(openssl passwd -1 -salt xyz hello)" >> password_hash
+
+# Fake EGA user
+WORKDIR ../cega_users
+RUN echo "---\npassword_hash: $(openssl passwd -1 -salt xyz hello)" >> john.yml
+
+# Populate configs
+WORKDIR ..
+RUN echo "[DEFAULT] \n\
+active_master_key = 1 \n\
+[master.key.1] \n\
+seckey = /etc/ega/rsa/sec.pem \n\
+pubkey = /etc/ega/rsa/pub.pem \n\
+passphrase = passphrase" >> keys.conf
+RUN echo "[DEFAULT] \n\
+log = debug \n\
+[ingestion] \n\
+gpg_cmd = /usr/local/bin/gpg --homedir ~/.gnupg --decrypt %(file)s \n\
+vhost = test \n\
+heartbeat = 0 \n\
+[db] \n\
+host = ega_db \n\
+username = user \n\
+password = password \n\
+[cega.broker] \n\
+host = cega_mq \n\
+username = test " >> conf.ini
+
+# Populate env-settings
+WORKDIR .env.d
+RUN echo "POSTGRES_USER=user\nPOSTGRES_PASSWORD=password" >> db && echo "GPG_PASSPHRASE=passphrase" >> gpg
+WORKDIR ..
+RUN echo "COMPOSE_PROJECT_NAME=ega \n\
+COMPOSE_FILE=ega.yml \n\
+CODE=../src \n\
+CONF=./conf.ini \n\
+KEYS=./keys.conf \n\
+SSL_CERT=./ssl_home/ssl.cert \n\
+SSL_KEY=./ssl_home/ssl.key \n\
+RSA_SEC=./rsa_home/sec.pem \n\
+RSA_PUB=./rsa_home/pub.pem \n\
+GPG_HOME=./gpg_home \n\
+CEGA_USERS=./cega_users" >> .env
+
+RUN mkdir ../configuration
+
+CMD echo "password = ${password}" >> conf.ini && cp -r . ../configuration 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,4 +103,4 @@ CEGA_USERS=./cega_users" >> .env
 
 RUN mkdir ../configuration
 
-CMD echo "password = ${password}" >> conf.ini && cp -r . ../configuration 
+CMD echo "password = ${password}" >> conf.ini && cp -r . ../configuration

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,20 @@
 # Deploy LocalEGA using Docker
 
-## The environment variables
+## Simplay way
+
+From within `docker` directory (where <password> is your Central EGA password):
+
+```
+docker build -t lega-setup . && \
+docker run -d -it --rm -v $(PWD):/configuration -e password=<password> --name lega-setup lega-setup:latest && \
+docker-compose up -d
+```
+
+That's it :) Check if everything is fine using `docker-compose ps`.
+
+## Hard way
+
+### The environment variables
 
 It is necessary to create a `.env` file with the following variables:
 (mostly used to parameterize docker-compose)
@@ -39,7 +53,7 @@ For the keyserver, we create `.env.d/gpg` containing:
 ```
 GPG_PASSPHRASE=the-correct-passphrase
 ```
-## The CONF file
+### The CONF file
 
 The file pointed by `CONF` should contain the values that reset those
 from [defaults.ini](../src/lega/conf/defaults.ini). For example:
@@ -69,7 +83,7 @@ password = <same-as-POSTGRES_PASSWORD-above>
 All the other values will remain unchanged.<br/>
 Use `docker-compose exec <some-container> ega-conf --list` in any container (but inbox).
 
-## The KEYS file
+### The KEYS file
 
 The file pointed by `KEYS` should contain the information about the
 keys and will be located _only_ on the keyserver. For example:
@@ -92,7 +106,7 @@ passphrase = <something-complex-too>
 Docker will map the path from `RSA_PUB` in the `.env` file to
 `/etc/ega/rsa/pub.pem` in the keyserver container, for example.
 
-## A Central EGA user
+### A Central EGA user
 
 We fake the CentralEGA message broker and user database, with 2
 containers: `cega_mq` and `cega_users`.
@@ -111,7 +125,7 @@ The file name `john.yml` is used for the user `john`. You must at
 least specify a `password_hash` or a `pubkey`. Other values can be
 empty or missing.
 
-# Running
+### Running
 
 	docker-compose up -d
 	
@@ -124,10 +138,10 @@ Note that, in this architecture, we use 3 separate volumes: one for
 the inbox area, one for the staging area, and one for the vault. They
 will be created on-the-fly by docker-compose.
 
-## Stopping
+### Stopping
 
 	docker-compose down -v
 
-## Status
+### Status
 
 	docker-compose ps

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Deploy LocalEGA using Docker
 
-## Simplay way
+## Simple way
 
 From within `docker` directory (where <password> is your Central EGA password):
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,8 +5,8 @@
 From within `docker` directory (where <password> is your Central EGA password):
 
 ```
-docker build -t lega-setup . && \
-docker run -d -it --rm -v $(PWD):/configuration -e password=<password> --name lega-setup lega-setup:latest && \
+docker build -t lega-bootstrap . && \
+docker run -d -it --rm -v $(PWD):/configuration -e password=<password> --name lega-bootstrap lega-bootstrap:latest && \
 docker-compose up -d
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,11 +2,11 @@
 
 ## Simple way
 
-From within `docker` directory (where <password> is your Central EGA password):
+From within `docker` directory:
 
 ```
 docker build -t lega-bootstrap . && \
-docker run -d -it --rm -v $(PWD):/configuration -e password=<password> --name lega-bootstrap lega-bootstrap:latest && \
+docker run -d -it --rm -v $(PWD):/configuration --name lega-bootstrap lega-bootstrap:latest && \
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Hi, everyone. After today's pain with deployment I decided to make our lives easier. For this purpose I created Docker image which does allllll the preparations and copies out required files (credits to @silverdaz for being patient and providing Makefile 😸 ). The only thing to specify manually is Central EGA password (see Slack for details). So the command to run is:

```
docker build -t lega-setup . && \
docker run -d -it --rm -v $(pwd):/configuration -e password=<Central EGA password> --name lega-setup lega-setup:latest && \
docker-compose up -d
```

Please, test it and feel free to make any suggestions. 

P.S. Linking it to my issue, because this is actually related to creating the CI pipeline.