### PR TITLE
Feature/wait-for-postgres

### DIFF
--- a/docker/ega.yml
+++ b/docker/ega.yml
@@ -38,7 +38,7 @@ services:
        - ${CODE}:/root/ega
        - ${ENTRYPOINTS}/frontend.sh:/usr/local/bin/frontend.sh:ro
        - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
-    command: wait-for-postgres.sh frontend.sh
+    command: ["wait-for-postgres.sh", "frontend.sh"]
 
   # SFTP inbox
   inbox:
@@ -58,7 +58,7 @@ services:
        - inbox:/ega/inbox
        - ${ENTRYPOINTS}/inbox.sh:/usr/local/bin/inbox.sh:ro
        - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
-    command: wait-for-postgres.sh inbox.sh
+    command: ["wait-for-postgres.sh", "inbox.sh"]
 
   # Vault
   vault:
@@ -79,7 +79,7 @@ services:
        - vault:/ega/vault
        - ${ENTRYPOINTS}/vault.sh:/usr/local/bin/vault.sh:ro
        - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
-    command: wait-for-postgres.sh vault.sh
+    command: ["wait-for-postgres.sh", "vault.sh"]
 
   # Ingestion Workers
   ingest:
@@ -104,7 +104,7 @@ services:
        - ${GPG_HOME}/trustdb.gpg:/root/.gnupg/trustdb.gpg
        - ${ENTRYPOINTS}/ingest.sh:/usr/local/bin/ingest.sh:ro
        - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
-    command: wait-for-postgres.sh ingest.sh
+    command: ["wait-for-postgres.sh", "ingest.sh"]
 
   # Key server
   keys:

--- a/docker/ega.yml
+++ b/docker/ega.yml
@@ -22,6 +22,7 @@ services:
 
   # ReST frontend
   frontend:
+    env_file: .env.d/db
     build: images/common
     depends_on:
       - db
@@ -36,7 +37,8 @@ services:
        - ${CONF}:/etc/ega/conf.ini:ro
        - ${CODE}:/root/ega
        - ${ENTRYPOINTS}/frontend.sh:/usr/local/bin/frontend.sh:ro
-    command: frontend.sh
+       - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
+    command: wait-for-postgres.sh frontend.sh
 
   # SFTP inbox
   inbox:
@@ -55,7 +57,8 @@ services:
        - ${CODE}:/root/ega
        - inbox:/ega/inbox
        - ${ENTRYPOINTS}/inbox.sh:/usr/local/bin/inbox.sh:ro
-    command: inbox.sh
+       - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
+    command: wait-for-postgres.sh inbox.sh
 
   # Vault
   vault:
@@ -74,7 +77,8 @@ services:
        - staging:/ega/staging
        - vault:/ega/vault
        - ${ENTRYPOINTS}/vault.sh:/usr/local/bin/vault.sh:ro
-    command: vault.sh
+       - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
+    command: wait-for-postgres.sh vault.sh
 
   # Ingestion Workers
   ingest:
@@ -97,7 +101,8 @@ services:
        - ${GPG_HOME}/pubring.kbx:/root/.gnupg/pubring.kbx:ro
        - ${GPG_HOME}/trustdb.gpg:/root/.gnupg/trustdb.gpg
        - ${ENTRYPOINTS}/ingest.sh:/usr/local/bin/ingest.sh:ro
-    command: ingest.sh
+       - ${ENTRYPOINTS}/wait-for-postgres.sh:/usr/local/bin/wait-for-postgres.sh:ro
+    command: wait-for-postgres.sh ingest.sh
 
   # Key server
   keys:

--- a/docker/ega.yml
+++ b/docker/ega.yml
@@ -68,6 +68,7 @@ services:
       - mq
       - cega_mq
       - inbox
+    env_file: .env.d/db
     hostname: ega_vault
     container_name: ega_vault
     image: nbis/ega:common
@@ -89,6 +90,7 @@ services:
       - cega_mq
       - keys
       - inbox
+    env_file: .env.d/db
     image: nbis/ega:worker
     environment:
       - GPG_TTY=/dev/console

--- a/docker/entrypoints/frontend.sh
+++ b/docker/entrypoints/frontend.sh
@@ -4,8 +4,5 @@ set -e
 
 pip3.6 install /root/ega
 
-echo "Waiting for database"
-until nc -4 --send-only ega_db 5432 </dev/null &>/dev/null; do sleep 1; done
-
 echo "Starting the frontend"
 exec ega-frontend

--- a/docker/entrypoints/inbox.sh
+++ b/docker/entrypoints/inbox.sh
@@ -50,8 +50,5 @@ PGPASSWORD=${POSTGRES_PASSWORD} psql -tqA -U ${POSTGRES_USER} -h ega_db -d lega 
 EOF
 chmod 755 /usr/local/bin/ega_ssh_keys.sh
 
-echo "Waiting for database"
-until nc -4 --send-only ega_db 5432 </dev/null &>/dev/null; do sleep 1; done
-
 echo "Starting the SFTP server"
 exec /usr/sbin/sshd -D -e

--- a/docker/entrypoints/ingest.sh
+++ b/docker/entrypoints/ingest.sh
@@ -15,8 +15,6 @@ echo "Waiting for Central Message Broker"
 until nc -4 --send-only cega_mq 5672 </dev/null &>/dev/null; do sleep 1; done
 echo "Waiting for Local Message Broker"
 until nc -4 --send-only ega_mq 5672 </dev/null &>/dev/null; do sleep 1; done
-echo "Waiting for database"
-until nc -4 --send-only ega_db 5432 </dev/null &>/dev/null; do sleep 1; done
 
 echo "Starting the ingestion worker"
 exec ega-ingest

--- a/docker/entrypoints/vault.sh
+++ b/docker/entrypoints/vault.sh
@@ -8,8 +8,6 @@ echo "Waiting for Central Message Broker"
 until nc -4 --send-only cega_mq 5672 </dev/null &>/dev/null; do sleep 1; done
 echo "Waiting for Local Message Broker"
 until nc -4 --send-only ega_mq 5672 </dev/null &>/dev/null; do sleep 1; done
-echo "Waiting for database"
-until nc -4 --send-only ega_db 5432 </dev/null &>/dev/null; do sleep 1; done
 
 echo "Starting the verifier"
 ega-verify &

--- a/docker/entrypoints/wait-for-postgres.sh
+++ b/docker/entrypoints/wait-for-postgres.sh
@@ -3,10 +3,15 @@
 set -e
 
 cmd="$@"
+SLEEPTIME=1
+RETRIES=30
 
 export PGPASSWORD=$POSTGRES_PASSWORD
 
-until psql -U $POSTGRES_USER -h ega_db -c "select 1"; do sleep 1; done
+until psql -U $POSTGRES_USER -h ega_db -c "select 1" || [ $RETRIES -eq 0 ]; do
+    echo "Waiting for Postgres server, $((RETRIES--)) remaining attempts..."
+        sleep SLEEPTIME;
+    done
 
 >&2 echo "Postgres is up - executing command"
 exec $cmd

--- a/docker/entrypoints/wait-for-postgres.sh
+++ b/docker/entrypoints/wait-for-postgres.sh
@@ -6,11 +6,11 @@ cmd="$@"
 SLEEPTIME=1
 RETRIES=30
 
-export PGPASSWORD=$POSTGRES_PASSWORD
+export PGPASSWORD=${POSTGRES_PASSWORD}
 
-until psql -U $POSTGRES_USER -h ega_db -c "select 1" || [ $RETRIES -eq 0 ]; do
+until psql -U ${POSTGRES_USER} -h ega_db -c "select 1" || [ ${RETRIES} -eq 0 ]; do
     echo "Waiting for Postgres server, $((RETRIES--)) remaining attempts..."
-        sleep SLEEPTIME;
+        sleep ${SLEEPTIME};
     done
 
 >&2 echo "Postgres is up - executing command"

--- a/docker/entrypoints/wait-for-postgres.sh
+++ b/docker/entrypoints/wait-for-postgres.sh
@@ -8,10 +8,16 @@ RETRIES=30
 
 export PGPASSWORD=${POSTGRES_PASSWORD}
 
+echo ${PGPASSWORD}
+
 until psql -U ${POSTGRES_USER} -h ega_db -c "select 1" || [ ${RETRIES} -eq 0 ]; do
     echo "Waiting for Postgres server, $((RETRIES--)) remaining attempts..."
-        sleep ${SLEEPTIME};
-    done
+    sleep ${SLEEPTIME}
+done
+
+if ! psql -U ${POSTGRES_USER} -h ega_db -c "select 1"; then
+    exit 1
+fi
 
 >&2 echo "Postgres is up - executing command"
 exec $cmd

--- a/docker/entrypoints/wait-for-postgres.sh
+++ b/docker/entrypoints/wait-for-postgres.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+cmd="$@"
+
+export PGPASSWORD=$POSTGRES_PASSWORD
+
+until psql -U $POSTGRES_USER -h ega_db -c "select 1"; do sleep 1; done
+
+>&2 echo "Postgres is up - executing command"
+exec $cmd

--- a/docker/images/common/Dockerfile
+++ b/docker/images/common/Dockerfile
@@ -5,7 +5,8 @@ RUN yum -y update && \
     yum -y install gcc git curl make bzip2 unzip \
     	   	   openssl \
 		   nss-tools nc nmap tcpdump lsof strace \
-	       	   bash-completion bash-completion-extras
+	       	   bash-completion bash-completion-extras \
+	       postgresql
 
 ##################################
 # For Python 3.6


### PR DESCRIPTION
Here's my fix for https://github.com/NBISweden/LocalEGA/issues/127

The problem is that currently we don't really wait for DB startup in all dependent services despite this part of entrypoints:
```bash
echo "Waiting for database"
until nc -4 --send-only ega_db 5432 </dev/null &>/dev/null; do sleep 1; done
```
This code checks only the fact of accessibility of Postgres server on port 5432. But even if it's accessible it doesn't mean it's operational. For more information refer to the issue here: https://github.com/docker-library/postgres/issues/146 They call it "double start" issue and we have the similar one, as far as I understand.

So I've implemented suggested approach and now we really check if the database is up **and running**.

Alternative was to use compose's `healthcheck`, but it's obsolete and not available for 3.2 version.

Another alternative was to use `pg_isready` tool instead of executing test query, but unfortunately it's unavailable in CentOS repository.