### PR TITLE
Hotfix/docker images

### DIFF
--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -22,5 +22,14 @@ The following images are created locally:
 |------------|:--------:|------|
 | nbis/ega   | db       | Sets up a postgres database with appropriate tables |
 | nbis/ega   | mq       | Sets up a RabbitMQ message broker with appropriate accounts, exchanges, queues and bindings |
-| nbis/ega   | common   | Image including python 3.6.1, GnuPG 2.2.0 and OpenSSH 7.5 |
+| nbis/ega   | common   | Image including python 3.6.1 |
 | nbis/ega   | inbox    | SFTP server on top of `nbis/ega:common` |
+| nbis/ega   | worker   | Adding GnuPG 2.2.0 to `nbis/ega:common` |
+| nbis/ega   | monitors | Including rsyslog |
+
+We also use 2 stubbing images in order to fake the necessary Central EGA components
+
+| Repository | Tag      | Role |
+|------------|:--------:|------|
+| nbis/ega   | cega\_users | Sets up a postgres database with appropriate tables |
+| nbis/ega   | cega\_mq    | Sets up a RabbitMQ message broker with appropriate accounts, exchanges, queues and bindings |

--- a/docker/images/inbox/sshd_config
+++ b/docker/images/inbox/sshd_config
@@ -35,7 +35,6 @@ MATCH GROUP ega USER *,!ega
   ChrootDirectory %h
   AuthorizedKeysCommand /usr/local/bin/ega_ssh_keys.sh
   AuthorizedKeysCommandUser ega
-  PasswordAuthentication yes
-  AuthenticationMethods "publickey" "keyboard-interactive:pam" "password"
+  AuthenticationMethods "publickey" "keyboard-interactive:pam"
   # -d (remote start directory relative user root)
   ForceCommand internal-sftp -d /inbox

--- a/docker/images/worker/Dockerfile
+++ b/docker/images/worker/Dockerfile
@@ -3,7 +3,10 @@ LABEL maintainer "Frédéric Haziza, NBIS"
 
 # Setup
 RUN gpg --list-keys && \
-    gpg --keyserver pgp.mit.edu --recv-keys 0x4F25E3B6 0xE0856959 0x33BD3F06 0x7EFD60D9 0xF7E48EDB
+    gpg --keyserver eu.pool.sks-keyservers.net \
+        --recv-keys 0x4F25E3B6 0xE0856959 0x33BD3F06 0x7EFD60D9 \
+	            0xF7E48EDB
+
 
 ##############################################################
 


### PR DESCRIPTION
Fixing the docker image for the ingestion worker by:
* Removing an offending key
* Updating the keyserver to a pool of servers
* Adding an extra signing key for `ncurses`

Moreover, we remove the `password` authentication method for the inbox image