### PR TITLE
Add cucumber test example

### DIFF
--- a/cucumber/.gitignore
+++ b/cucumber/.gitignore
@@ -1,0 +1,17 @@
+# Log file
+*.log
+
+# Idea files
+.idea
+*.iml
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+target
+out

--- a/cucumber/pom.xml
+++ b/cucumber/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>no.uio.ifi.lega</groupId>
+    <groupId>se.nbis.lega</groupId>
     <artifactId>cucumber</artifactId>
     <version>1.0-SNAPSHOT</version>
     <build>

--- a/cucumber/pom.xml
+++ b/cucumber/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>no.uio.ifi.lega</groupId>
+    <artifactId>cucumber</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <cucumber.version>1.2.5</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.hierynomus</groupId>
+            <artifactId>sshj</artifactId>
+            <version>0.22.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java8</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/cucumber/src/test/java/se/nbis/lega/cucumber/Tests.java
+++ b/cucumber/src/test/java/se/nbis/lega/cucumber/Tests.java
@@ -1,0 +1,13 @@
+package se.nbis.lega.cucumber;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        format = {"pretty", "html:target/cucumber"},
+        features = "classpath:authentication.feature"
+)
+public class Tests {
+}

--- a/cucumber/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
+++ b/cucumber/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
@@ -34,15 +34,15 @@ public class Authentication implements En {
                 ssh.authPublickey(USERNAME, privateKey.getPath());
                 sftp = ssh.newSFTPClient();
             } catch (Exception e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         });
 
         Then("the operation is successful", () -> {
             try {
                 Assert.assertEquals("inbox", sftp.ls("/").iterator().next().getName());
-            } catch (IOException e) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         });
     }

--- a/cucumber/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
+++ b/cucumber/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
@@ -1,0 +1,50 @@
+package se.nbis.lega.cucumber.steps;
+
+import cucumber.api.java.Before;
+import cucumber.api.java8.En;
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
+import org.junit.Assert;
+
+import java.io.File;
+import java.io.IOException;
+
+public class Authentication implements En {
+
+    private static final String USERNAME = "john";
+
+    private File privateKey;
+
+    private SFTPClient sftp;
+
+    @Before
+    public void setUp() throws IOException {
+        privateKey = new File("../docker/bootstrap/private/cega/users/" + USERNAME + ".sec");
+    }
+
+    public Authentication() {
+        Given("I have a private key", () -> Assert.assertNotNull(privateKey));
+
+        When("I try to connect to the LocalEGA inbox via SFTP using private key", () -> {
+            try {
+                SSHClient ssh = new SSHClient();
+                ssh.addHostKeyVerifier(new PromiscuousVerifier());
+                ssh.connect("localhost", 2222);
+                ssh.authPublickey(USERNAME, privateKey.getPath());
+                sftp = ssh.newSFTPClient();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        Then("the operation is successful", () -> {
+            try {
+                Assert.assertEquals("inbox", sftp.ls("/").iterator().next().getName());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+}

--- a/cucumber/src/test/resources/authentication.feature
+++ b/cucumber/src/test/resources/authentication.feature
@@ -1,0 +1,7 @@
+Feature: Authentication
+  As a user I want to be able to authenticate against LocalEGA inbox
+
+  Scenario: Authenticate against LocalEGA inbox using private key
+    Given I have a private key
+    When I try to connect to the LocalEGA inbox via SFTP using private key
+    Then the operation is successful

--- a/docker/images/Makefile
+++ b/docker/images/Makefile
@@ -6,7 +6,7 @@ all: $(EGA_IMAGES)
 .PHONY: all $(EGA_IMAGES)
 
 $(EGA_IMAGES):
-	docker build --no-cache -t nbis/ega:$@ $@
+	docker build -t nbis/ega:$@ $@
 
 clean:
 	docker images | awk '/none/{print $$3}' | while read n; do docker rmi $$n; done


### PR DESCRIPTION
**Notes:**
- Now `Authentication` test uses key-pair, so there's no need to enable non-interactive password authentication anymore.
- Java package is renamed in favour of `nbis.se`.
- Test-suite is platform-agnostic, so we don't need to wait for the decision on CI platform to have it in `dev`: it can be run on both OpenShift and OpenStack (or simply locally).
- Tested on Jenkins in OpenStack: http://158.39.77.10/job/LocalEGA/

**Things to discuss:**
- Should we have `--no-chache` option in `Makefile` for images or not? I've put it there some time ago to be sure that CI server will always work with the fresh data and won't omit changes made, for example, to `sshd_config`. But now I doubt it was a good idea, since such "fair" test is dramatically slow - and it will take so much time on each commit. So I removed this option in this PR - just as it was before. 