### PR TITLE
Reformating for Codacy

### DIFF
--- a/docker/images/cega_mq/publish.py
+++ b/docker/images/cega_mq/publish.py
@@ -5,7 +5,6 @@
 creation of a user or the ingestion of a file.
 '''
 
-import sys
 import argparse
 import uuid
 import json
@@ -28,7 +27,6 @@ enc_group.add_argument('--enc')
 enc_group.add_argument('--enc_algo', default='md5', help='[Default: md5]')
 
 args = parser.parse_args()
-
 
 message = { 'elixir_id': args.user, 'filename': args.filename }
 if args.enc:

--- a/src/lega/__init__.py
+++ b/src/lega/__init__.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 # __init__ is here so that we don't collapse in sys.path with another lega module
 
-f"""Local EGA library
-~~~~~~~~~~~~~~~~~~~~~
+"""\
+Local EGA library
+~~~~~~~~~~~~~~~~~
 
 The lega package contains code to start a _Local EGA_.
 
 See `https://github.com/NBISweden/LocalEGA` for a full documentation.
+
 :copyright: (c) 2017, NBIS System Developers.
 """
 

--- a/src/lega/conf/__init__.py
+++ b/src/lega/conf/__init__.py
@@ -12,12 +12,13 @@ _config_files =  [
  ]
 
 _loggers =  {
-    'default': _here / 'loggers/default.yaml', 
-    'debug':  _here / 'loggers/debug.yaml', 
-    'syslog': _here / 'loggers/syslog.yaml', 
+    'default': _here / 'loggers/default.yaml',
+    'debug':  _here / 'loggers/debug.yaml',
+    'syslog': _here / 'loggers/syslog.yaml',
 }
 
-f"""This module provides a dictionary-like with configuration settings.
+f"""\
+This module provides a dictionary-like with configuration settings.
 It also loads the logging settings when `setup` is called.
 
 The `--log <file>` argument is used to configuration where the logs go.
@@ -37,8 +38,8 @@ The files must be either in `INI` format or in `YAML` format, in
 which case, it must end in `.yaml` or `.yml`.
 
 See `https://github.com/NBISweden/LocalEGA` for a full documentation.
-:copyright: (c) 2017, NBIS System Developers.
 
+:copyright: (c) 2017, NBIS System Developers.
 """
 
 class Configuration(configparser.ConfigParser):
@@ -110,7 +111,6 @@ class Configuration(configparser.ConfigParser):
 
         print(f"Unsupported log format for {filename}", file=sys.stderr)
         self.log_conf = None
-            
 
     def _load_log_conf(self,args=None):
         # Finding the --log file

--- a/src/lega/ingest.py
+++ b/src/lega/ingest.py
@@ -28,9 +28,7 @@ import os
 import logging
 from pathlib import Path
 import shutil
-import stat
 import uuid
-from multiprocessing import Process, cpu_count
 import ssl
 from functools import partial
 import asyncio

--- a/src/lega/monitor.py
+++ b/src/lega/monitor.py
@@ -17,7 +17,7 @@ import sys
 import logging
 import argparse
 from time import sleep
-    
+
 from .conf import CONF
 from .utils import db
 

--- a/src/lega/utils/amqp.py
+++ b/src/lega/utils/amqp.py
@@ -41,8 +41,8 @@ def get_connection(domain, blocking=True):
             'ca_certs' : CONF.get(domain,'cacert'),
             'certfile' : CONF.get(domain,'cert'),
             'keyfile'  : CONF.get(domain,'keyfile'),
-            'cert_reqs': 2 #ssl.CERT_REQUIRED is actually <VerifyMode.CERT_REQUIRED: 2>
-        } 
+            'cert_reqs': 2, #ssl.CERT_REQUIRED is actually <VerifyMode.CERT_REQUIRED: 2>
+        }
 
     LOG.info(f'Getting a connection to {domain}')
     LOG.debug(params)

--- a/src/lega/utils/crypto.py
+++ b/src/lega/utils/crypto.py
@@ -9,7 +9,6 @@
 '''
 
 import logging
-import io
 import os
 import asyncio
 import asyncio.subprocess
@@ -91,20 +90,20 @@ class ReEncryptor(asyncio.SubprocessProtocol):
         encryption_key, mode, nonce = next(self.engine)
 
         self.header = make_header(active_key, len(encryption_key), len(nonce), mode.encode())
-    
+        
         LOG.info(f'Writing header to file: {self.header} (and enc key + nonce)')
         header_b = (self.header + '\n').encode()
-
+        
         self.target_handler.write(header_b)
         self.target_handler.write(encryption_key)
         self.target_handler.write(nonce)
-
+        
         LOG.info('Setup target digest')
         self.target_digest = sha256()
         self.target_digest.update(header_b)
         self.target_digest.update(encryption_key)
         self.target_digest.update(nonce)
-
+        
         # And now, daddy...
         super().__init__()
 
@@ -113,7 +112,7 @@ class ReEncryptor(asyncio.SubprocessProtocol):
         self.transport = transport
 
     def pipe_data_received(self, fd, data):
-        # Data is of size: 32768 or 65536 bytes 
+        # Data is of size: 32768 or 65536 bytes
         if not data:
             return
         if fd == 1:
@@ -188,7 +187,7 @@ def ingest(gpg_cmd,
             _err = exceptions.Checksum(hash_algo,f'for decrypted content of {enc_file}')
             LOG.error(str(_err))
 
-    if _err:
+    if _err is not None:
         LOG.warning(f'Removing {target}')
         os.remove(target)
         raise _err

--- a/src/lega/utils/db.py
+++ b/src/lega/utils/db.py
@@ -258,7 +258,7 @@ def catch_error(func):
             if isinstance(e,AssertionError):
                 raise e
 
-            exc_type, exc_obj, exc_tb = sys.exc_info()
+            exc_type, _, exc_tb = sys.exc_info()
             g = traceback.walk_tb(exc_tb)
             frame, lineno = next(g) # that should be the decorator
             try:

--- a/src/lega/utils/socket.py
+++ b/src/lega/utils/socket.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-'''
-Unix Domain Socket forwarding to remote machine and 
-proxying remote requests to a given Unix Domain Socket.
+'''\
+Unix Domain Socket forwarding to remote machine and proxying remote requests to a given Unix Domain Socket.
 
 Usefull to forward gpg requests to a remote GPG-agent.
 
 :author: Frédéric Haziza
 :copyright: (c) 2017, NBIS System Developers.
+
 '''
 
 import sys
@@ -147,7 +147,7 @@ def proxy():
     keyfile = Path(args.keyfile).expanduser() if args.keyfile else None
     syslog(LOG_DEBUG, f'Certfile: {certfile}')
     syslog(LOG_DEBUG, f'Keyfile: {keyfile}')
-    if (certfile and certfile.exists() and 
+    if (certfile and certfile.exists() and
         keyfile and keyfile.exists()):
         ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         ssl_ctx.load_cert_chain(certfile, keyfile)

--- a/src/lega/vault.py
+++ b/src/lega/vault.py
@@ -51,7 +51,7 @@ def work(data):
     starget = str(target)
     LOG.debug(f'Moving {filepath} to {target}')
     shutil.move(str(filepath), starget)
-    
+
     # Mark it as processed in DB
     db.finalize_file(file_id, starget, target.stat().st_size)
 

--- a/src/lega/verify.py
+++ b/src/lega/verify.py
@@ -29,13 +29,13 @@ def work(data):
     '''Verifying that the file in the vault does decrypt properly'''
 
     file_id = data['file_id']
-    filename, org_hash, org_hash_algo, vault_filename, vault_checksum = db.get_details(file_id)
+    filename, _, org_hash_algo, vault_filename, vault_checksum = db.get_details(file_id)
 
     if not checksum.is_valid(vault_filename, vault_checksum, hashAlgo='sha256'):
         raise exceptions.VaultDecryption(vault_filename)
 
     return { 'vault_name': vault_filename, 'org_name': filename }
-    
+
 def main(args=None):
 
     if not args:


### PR DESCRIPTION
Trying to make Codacy happy.

Codacy was mostly picking up on trailing white-spaces and unused python packages (the latter because of code update or reformatting).

Note: I think that some of the Codacy tests are wrong.
For example, in python, a string that is not dumped into a variable is a comment.
The triple quote `"""` is used to format string including line breaks (like heredocs), and it is common practice to use them for documentation. Codacy doesn't seem to like them at the module level. Maybe it's right, and we should write the module documentation in another way.