### PR TITLE
Add caching from nbis/ega Docker Hub repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,25 @@ language: generic
 services:
   - docker
 
-script:
-  - cd docker
-  - make -C images
-  - docker run --rm -i -v ${PWD}/bootstrap:/ega nbis/ega:worker /ega/generate.sh -f
-  - bootstrap/populate.sh
-  - sudo chown -R $USER .
+before_install:
+  - |
+        cd docker
+        docker pull -a nbis/ega
+        make -C images
+        docker run --rm -i -v ${PWD}/bootstrap:/ega nbis/ega:worker /ega/generate.sh -f
+        bootstrap/populate.sh
+        sudo chown -R $USER .
+
+install:
   - docker-compose up -d
+
+script:
   - cd ../tests
   - mvn test -B
+
+after_success:
+  - |
+        if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+            docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+            docker push nbis/ega
+        fi

--- a/docker/images/Makefile
+++ b/docker/images/Makefile
@@ -6,7 +6,7 @@ all: $(EGA_IMAGES)
 .PHONY: all $(EGA_IMAGES)
 
 $(EGA_IMAGES):
-	docker build -t nbis/ega:$@ $@
+	docker build --cache-from nbis/ega:$@ --tag nbis/ega:$@ $@
 
 clean:
 	docker images | awk '/none/{print $$3}' | while read n; do docker rmi $$n; done


### PR DESCRIPTION
Now the building of Docker images is backed by remote cache: https://hub.docker.com/r/nbis/ega/

Speed boost: 10+ mins -> less than 3 mins.

This cache can be updated manually from your local machine by calling `docker push nbis/ega`. Also it's updated automatically upon successful build of `master` branch (push or merge commit - not Pull Request).