### PR TITLE
Fixing pip install failure

### DIFF
--- a/docker/entrypoints/frontend.sh
+++ b/docker/entrypoints/frontend.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-pip3.6 install /root/ega
+cp -r /root/ega /root/run
+pip3.6 install /root/run
 
 echo "Starting the frontend"
 exec ega-frontend

--- a/docker/entrypoints/inbox.sh
+++ b/docker/entrypoints/inbox.sh
@@ -6,7 +6,8 @@ chown root:ega /ega/inbox
 chmod 750 /ega/inbox
 chmod g+s /ega/inbox # setgid bit
 
-pushd /root/ega/auth
+cp -r /root/ega /root/run
+pushd /root/run/auth
 make install clean
 ldconfig -v
 popd

--- a/docker/entrypoints/ingest.sh
+++ b/docker/entrypoints/ingest.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-pip3.6 install /root/ega
+cp -r /root/ega /root/run
+pip3.6 install /root/run
 
 # echo "Waiting for Keyserver"
 # until nc -4 --send-only ega_keys 9010 </dev/null &>/dev/null; do sleep 1; done

--- a/docker/entrypoints/keys.sh
+++ b/docker/entrypoints/keys.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-pip3.6 install /root/ega
+cp -r /root/ega /root/run
+pip3.6 install /root/run
 
 echo "Starting the key management server"
 ega-keyserver --keys /etc/ega/keys.ini &

--- a/docker/entrypoints/vault.sh
+++ b/docker/entrypoints/vault.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-pip3.6 install /root/ega
+cp -r /root/ega /root/run
+pip3.6 install /root/run
 
 echo "Waiting for Central Message Broker"
 until nc -4 --send-only cega_mq 5672 </dev/null &>/dev/null; do sleep 1; done


### PR DESCRIPTION
Copy mounted code somewhere else first.

Nothing runs in the mounted volume.
The command runs in the copied folder, so no race between containers.