### PR TITLE
Remove hard-coded gpg email for presetting the passphrase

### DIFF
--- a/deployments/docker/bootstrap/lib/instance.sh
+++ b/deployments/docker/bootstrap/lib/instance.sh
@@ -111,7 +111,6 @@ host = ega_frontend_${INSTANCE}
 keyserver_host = ega_keys_${INSTANCE}
 EOF
 
-
 #########################################################################
 # Populate env-settings for docker compose
 #########################################################################
@@ -126,6 +125,7 @@ POSTGRES_DB=lega
 EOF
 
 cat > ${PRIVATE}/${INSTANCE}/gpg.env <<EOF
+GPG_EMAIL=${GPG_EMAIL}
 GPG_PASSPHRASE=${GPG_PASSPHRASE}
 EOF
 

--- a/deployments/docker/images/keys/entrypoint.sh
+++ b/deployments/docker/images/keys/entrypoint.sh
@@ -17,12 +17,12 @@ ${GPG_AGENT} --daemon
 # This should create /run/ega/S.gpg-agent{,.extra,.ssh}
 
 #while gpg-connect-agent /bye; do sleep 2; done
-KEYGRIP=$(${GPG} -k --with-keygrip ega@nbis.se | awk '/Keygrip/{print $3;exit;}')
-${GPG_PRESET} --preset -P $GPG_PASSPHRASE $KEYGRIP
+KEYGRIP=$(${GPG} -k --with-keygrip ${GPG_EMAIL} | awk '/Keygrip/{print $3;exit;}')
+${GPG_PRESET} --preset -P ${GPG_PASSPHRASE} ${KEYGRIP}
 unset GPG_PASSPHRASE
 
 echo "Starting the gpg-agent proxy"
-ega-socket-proxy "0.0.0.0:$KEYSERVER_PORT" /root/.gnupg/S.gpg-agent --certfile /etc/ega/ssl.cert --keyfile /etc/ega/ssl.key &
+ega-socket-proxy "0.0.0.0:${KEYSERVER_PORT}" /root/.gnupg/S.gpg-agent --certfile /etc/ega/ssl.cert --keyfile /etc/ega/ssl.key &
 
 echo "Starting the key management server"
 exec ega-keyserver --keys /etc/ega/keys.ini


### PR DESCRIPTION
The entrypoint had a hard-coded value.
Removing it and updating the bootstrap to put the setting in private/gpg.env