### PR TITLE
Workers are instantiated.

### DIFF
--- a/deployments/terraform/hosts.allow
+++ b/deployments/terraform/hosts.allow
@@ -1,5 +1,4 @@
 sshd: 192.168.10.0/24 : spawn (/usr/bin/logger -i -p authpriv.info "%d[%p]\: %h (allowed local)")&    : ALLOW
 sshd: 84.88.66.194    : spawn (/usr/bin/logger -i -p authpriv.info "%d[%p]\: %h (allowed fred@crg)")& : ALLOW
-sshd: 139.47.14.159   : spawn (/usr/bin/logger -i -p authpriv.info "%d[%p]\: %h (allowed fred@bcn)")& : ALLOW
 sshd: .se             : spawn (/usr/bin/logger -i -p authpriv.info "%d[%p]\: %h (allowed .se)")&      : ALLOW
 ALL : ALL             : spawn (/usr/bin/logger -i -p authpriv.info "%d[%p]\: %h (denied)")&           : DENY

--- a/deployments/terraform/instances/workers/cloud_init.tpl
+++ b/deployments/terraform/instances/workers/cloud_init.tpl
@@ -53,7 +53,7 @@ write_files:
   - encoding: b64
     content: ${ega_ingest}
     owner: root:root
-    path: /etc/systemd/system/ega-ingestion.service
+    path: /etc/systemd/system/ega-ingestion@.service
     permissions: '0644'
   - encoding: b64
     content: ${ega_inbox_mount}
@@ -77,7 +77,9 @@ bootcmd:
 runcmd:
   - ldconfig -v
   - pip3.6 install git+https://github.com/NBISweden/LocalEGA.git
-  - systemctl start ega-ingestion.service ega-socket-forwarder.service ega-socket-forwarder.socket
-  - systemctl enable ega-ingestion.service ega-socket-forwarder.service ega-socket-forwarder.socket
+  - systemctl start ega-socket-forwarder.service ega-socket-forwarder.socket
+  - systemctl enable ega-socket-forwarder.service ega-socket-forwarder.socket
+  - systemctl start ega-ingestion@1.service ega-ingestion@2.service
+  - systemctl enable ega-ingestion@1.service ega-ingestion@2.service
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/deployments/terraform/instances/workers/main.tf
+++ b/deployments/terraform/instances/workers/main.tf
@@ -25,7 +25,7 @@ data "template_file" "cloud_init" {
     ega_slice   = "${base64encode("${file("${path.root}/systemd/ega.slice")}")}"
     ega_socket  = "${base64encode("${file("${path.root}/systemd/ega-socket-forwarder.socket")}")}"
     ega_forward = "${base64encode("${file("${path.root}/systemd/ega-socket-forwarder.service")}")}"
-    ega_ingest  = "${base64encode("${file("${path.root}/systemd/ega-ingestion.service")}")}"
+    ega_ingest  = "${base64encode("${file("${path.root}/systemd/ega-ingestion@.service")}")}"
     ega_inbox_mount   = "${base64encode("${file("${path.root}/systemd/ega-inbox.mount")}")}"
     ega_staging_mount = "${base64encode("${file("${path.root}/systemd/ega-staging.mount")}")}"
   }

--- a/deployments/terraform/systemd/ega-ingestion@.service
+++ b/deployments/terraform/systemd/ega-ingestion@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=EGA Ingestion service
+Description=EGA Ingestion service (%I)
 After=syslog.target
 After=network.target
 
@@ -11,24 +11,18 @@ After=ega-inbox.mount ega-staging.mount
 [Service]
 Slice=ega.slice
 Type=simple
-#Restart=always
 EnvironmentFile=/etc/ega/options
 Environment=EGA_FORCE_GNUPG=yes
 ExecStart=/usr/bin/ega-ingest $EGA_OPTIONS
 User=ega
 Group=ega
 
-# PermissionsStartOnly=true
-# ExecStartPre=/usr/bin/chown ega:ega /ega/staging
-# ExecStartPre=/usr/bin/chmod 700 /ega/staging
-# ExecStartPre=/usr/bin/chmod g+s /ega/staging
-
 StandardOutput=syslog
 StandardError=syslog
 
-#Restart=on-failure
-#RestartSec=10
-#TimeoutSec=600
+Restart=on-failure
+RestartSec=10
+TimeoutSec=600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
```
systemctl start ega-ingestion@1.service
systemctl start ega-ingestion@2.service
```
will start 2 ingestion workers independant from each other.

Workers also restart on failure (eg, when they can't contact the database or the message broker)