### PR TITLE
 Use Bouncy Castle (actually JPGPJ wrapper) in tests to encrypt files

### DIFF
--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -46,6 +46,7 @@ EOF
 ${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --batch --generate-key ${PRIVATE}/${INSTANCE}/gen_key
 ${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --armor --export -a "${GPG_NAME}" > ${PRIVATE}/${INSTANCE}/gpg/public.key
 chmod 700 ${PRIVATE}/${INSTANCE}/gpg
+chmod 744 ${PRIVATE}/${INSTANCE}/gpg/public.key
 rm -f ${PRIVATE}/${INSTANCE}/gen_key
 ${GPG_CONF} --kill gpg-agent
 

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -44,6 +44,7 @@ Passphrase: ${GPG_PASSPHRASE}
 EOF
 
 ${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --batch --generate-key ${PRIVATE}/${INSTANCE}/gen_key
+${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --armor --export -a "${GPG_NAME}" > ${PRIVATE}/${INSTANCE}/gpg/public.key
 chmod 700 ${PRIVATE}/${INSTANCE}/gpg
 rm -f ${PRIVATE}/${INSTANCE}/gen_key
 ${GPG_CONF} --kill gpg-agent

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -45,7 +45,7 @@ EOF
 
 ${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --batch --generate-key ${PRIVATE}/${INSTANCE}/gen_key
 ${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --armor --export -a "${GPG_NAME}" > ${PRIVATE}/${INSTANCE}/gpg/public.key
-chmod 744 ${PRIVATE}/${INSTANCE}/gpg
+chmod 755 ${PRIVATE}/${INSTANCE}/gpg
 chmod 744 ${PRIVATE}/${INSTANCE}/gpg/public.key
 rm -f ${PRIVATE}/${INSTANCE}/gen_key
 ${GPG_CONF} --kill gpg-agent

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -45,7 +45,7 @@ EOF
 
 ${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --batch --generate-key ${PRIVATE}/${INSTANCE}/gen_key
 ${GPG} --homedir ${PRIVATE}/${INSTANCE}/gpg --armor --export -a "${GPG_NAME}" > ${PRIVATE}/${INSTANCE}/gpg/public.key
-chmod 700 ${PRIVATE}/${INSTANCE}/gpg
+chmod 744 ${PRIVATE}/${INSTANCE}/gpg
 chmod 744 ${PRIVATE}/${INSTANCE}/gpg/public.key
 rm -f ${PRIVATE}/${INSTANCE}/gen_key
 ${GPG_CONF} --kill gpg-agent

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -25,7 +25,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <cucumber.version>1.2.5</cucumber.version>
-        <org.bouncycastle.version>1.58</org.bouncycastle.version>
         <jackson.version>2.9.3</jackson.version>
         <rabbitmq.version>5.1.1</rabbitmq.version>
     </properties>
@@ -57,6 +56,12 @@
             <groupId>com.hierynomus</groupId>
             <artifactId>sshj</artifactId>
             <version>0.22.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.c02e.jpgpj</groupId>
+            <artifactId>jpgpj</artifactId>
+            <version>0.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Saves ~3 minutes of build-time (now it's 7 instead of 10, according to the estimations), since we don't spawn temporary Docker containers for encryption anymore.