### PR TITLE
Use Java to generate RSA keys for SSH connection in tests

### DIFF
--- a/deployments/docker/bootstrap/cega_users.sh
+++ b/deployments/docker/bootstrap/cega_users.sh
@@ -6,7 +6,6 @@ echomsg "Generating fake Central EGA users"
 [[ -x $(readlink ${OPENSSL}) ]] && echo "${OPENSSL} is not executable. Adjust the setting with --openssl" && exit 3
 
 mkdir -p ${PRIVATE}/cega/users
-chmod 755 ${PRIVATE}/cega/users
 
 EGA_USER_PASSWORD_JOHN=$(generate_password 16)
 EGA_USER_PASSWORD_JANE=$(generate_password 16)
@@ -43,6 +42,7 @@ password_hash: $(${OPENSSL} passwd -1 ${EGA_USER_PASSWORD_TAYLOR})
 EOF
 
 mkdir -p ${PRIVATE}/cega/users/{swe1,fin1}
+chmod 755 ${PRIVATE}/cega/users/{swe1,fin1}
 # They all have access to SWE1
 ( # In a subshell
     cd ${PRIVATE}/cega/users/swe1

--- a/deployments/docker/bootstrap/cega_users.sh
+++ b/deployments/docker/bootstrap/cega_users.sh
@@ -42,7 +42,7 @@ password_hash: $(${OPENSSL} passwd -1 ${EGA_USER_PASSWORD_TAYLOR})
 EOF
 
 mkdir -p ${PRIVATE}/cega/users/{swe1,fin1}
-chmod 755 ${PRIVATE}/cega/users/{swe1,fin1}
+chmod 777 ${PRIVATE}/cega/users/{swe1,fin1}
 # They all have access to SWE1
 ( # In a subshell
     cd ${PRIVATE}/cega/users/swe1

--- a/deployments/docker/bootstrap/cega_users.sh
+++ b/deployments/docker/bootstrap/cega_users.sh
@@ -6,6 +6,7 @@ echomsg "Generating fake Central EGA users"
 [[ -x $(readlink ${OPENSSL}) ]] && echo "${OPENSSL} is not executable. Adjust the setting with --openssl" && exit 3
 
 mkdir -p ${PRIVATE}/cega/users
+chmod 755 ${PRIVATE}/cega/users
 
 EGA_USER_PASSWORD_JOHN=$(generate_password 16)
 EGA_USER_PASSWORD_JANE=$(generate_password 16)

--- a/tests/src/test/java/se/nbis/lega/cucumber/Context.java
+++ b/tests/src/test/java/se/nbis/lega/cucumber/Context.java
@@ -3,9 +3,12 @@ package se.nbis.lega.cucumber;
 import lombok.Data;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
+import net.schmizz.sshj.userauth.keyprovider.KeyProviderUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.KeyPair;
 import java.util.List;
 
 @Data
@@ -16,7 +19,7 @@ public class Context {
     private String user;
     private List<String> instances;
     private String targetInstance;
-    private File privateKey;
+    private KeyProvider keyProvider;
     private String cegaMQUser;
     private String cegaMQPassword;
     private String cegaMQVHost;

--- a/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
+++ b/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
@@ -179,7 +179,9 @@ public class Utils {
      * @param to       Folder to mount to.
      * @param commands Command to execute.
      * @return Execution result per command.
+     * @deprecated Very slow, thus not used anymore. Try to avoid usage of this method.
      */
+    @Deprecated
     public List<String> spawnTempWorkerAndExecute(String instance, String from, String to, String... commands) {
         List<String> results = new ArrayList<>();
         String workerImageName = getProperty("images.name.worker");

--- a/tests/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
+++ b/tests/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
@@ -5,6 +5,7 @@ import cucumber.api.java8.En;
 import lombok.extern.slf4j.Slf4j;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.sftp.SFTPException;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 import net.schmizz.sshj.userauth.UserAuthException;
 import net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper;
@@ -158,7 +159,7 @@ public class Authentication implements En {
             context.setSsh(ssh);
             context.setSftp(ssh.newSFTPClient());
             context.setAuthenticationFailed(false);
-        } catch (UserAuthException e) {
+        } catch (UserAuthException | SFTPException e) {
             context.setAuthenticationFailed(true);
         } catch (IOException e) {
             log.error(e.getMessage(), e);

--- a/tests/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
+++ b/tests/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
@@ -41,7 +41,6 @@ public class Authentication implements En {
                     generateKeypair(context);
                     byte[] keyBytes = new Buffer.PlainBuffer().putPublicKey(context.getKeyProvider().getPublic()).getCompactData();
                     String publicKey = Base64.getEncoder().encodeToString(keyBytes);
-                    System.out.println("publicKey = " + publicKey);
                     File userYML = new File(String.format(cegaUsersFolderPath + "/%s.yml", user));
                     FileUtils.writeLines(userYML, Arrays.asList("---", "pubkey: ssh-rsa " + publicKey));
                 } catch (IOException e) {


### PR DESCRIPTION
SSHJ library allows generating keys for SSH connection without the need to spawn temporary Docker container.