### PR TITLE
Handling stable IDs from CentralEGA.

### DIFF
--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -46,9 +46,11 @@ chmod 644 ${PRIVATE}/${INSTANCE}/pgp/ega2.pub
 #########################################################################
 
 echomsg "\t* the RSA public and private key"
+#${OPENSSL} genpkey -algorithm RSA -pass pass:"${RSA_PASSPHRASE}" -out ${PRIVATE}/${INSTANCE}/rsa/ega.sec -pkeyopt rsa_keygen_bits:2048
 ${OPENSSL} genpkey -algorithm RSA -out ${PRIVATE}/${INSTANCE}/rsa/ega.sec -pkeyopt rsa_keygen_bits:2048
 ${OPENSSL} rsa -pubout -in ${PRIVATE}/${INSTANCE}/rsa/ega.sec -out ${PRIVATE}/${INSTANCE}/rsa/ega.pub
 
+#${OPENSSL} genpkey -algorithm RSA -pass pass:"${RSA_PASSPHRASE}" -out ${PRIVATE}/${INSTANCE}/rsa/ega2.sec -pkeyopt rsa_keygen_bits:2048
 ${OPENSSL} genpkey -algorithm RSA -out ${PRIVATE}/${INSTANCE}/rsa/ega2.sec -pkeyopt rsa_keygen_bits:2048
 ${OPENSSL} rsa -pubout -in ${PRIVATE}/${INSTANCE}/rsa/ega2.sec -out ${PRIVATE}/${INSTANCE}/rsa/ega2.pub
 
@@ -68,10 +70,12 @@ pgp : pgp.key.1
 [rsa.key.1]
 public : /etc/ega/rsa/ega.pub
 private : /etc/ega/rsa/ega.sec
+#passphrase : ${RSA_PASSPHRASE}
 
 [rsa.key.2]
 public : /etc/ega/rsa/ega2.pub
 private : /etc/ega/rsa/ega2.sec
+#passphrase : ${RSA_PASSPHRASE}
 
 [pgp.key.1]
 public : /etc/ega/pgp/ega.pub
@@ -448,6 +452,8 @@ services:
     tty: true
     expose:
       - "443"
+    ports:
+      - "${DOCKER_PORT_keyserver}:443"
     volumes:
        - ./${INSTANCE}/ega.conf:/etc/ega/conf.ini:ro
        - ./${INSTANCE}/logger.yml:/etc/ega/logger.yml:ro
@@ -489,7 +495,7 @@ services:
        - ./${INSTANCE}/ega.conf:/etc/ega/conf.ini:ro
        - ./${INSTANCE}/logger.yml:/etc/ega/logger.yml:ro
        - ../images/vault/entrypoint.sh:/usr/local/bin/entrypoint.sh
-       # - ../../../lega:/root/.local/lib/python3.6/site-packages/lega
+       - ../../../lega:/root/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     networks:
       - lega_${INSTANCE}

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -93,8 +93,8 @@ log = /etc/ega/logger.yml
 
 [ingestion]
 # Keyserver communication
-keyserver_endpoint_pgp = https://ega-keys-${INSTANCE}/retrieve/pgp/%s
-keyserver_endpoint_rsa = https://ega-keys-${INSTANCE}/active/rsa
+keyserver_endpoint_pgp = http://ega-keys-${INSTANCE}:443/retrieve/pgp/%s
+keyserver_endpoint_rsa = http://ega-keys-${INSTANCE}:443/active/rsa
 
 decrypt_cmd = python3.6 -u -m lega.openpgp %(file)s
 

--- a/deployments/docker/bootstrap/settings/fin1
+++ b/deployments/docker/bootstrap/settings/fin1
@@ -4,6 +4,7 @@ set -e
 DOCKER_PORT_inbox=2223
 DOCKER_PORT_mq=15673
 DOCKER_PORT_kibana=5602
+DOCKER_PORT_keyserver=8444
 
 LEGA_GREETINGS="Welcome to Local EGA Finland @ CSC"
 CEGA_MQ_PASSWORD=$(generate_password 16)
@@ -19,5 +20,7 @@ PGP_NAME="EGA Finland"
 PGP_COMMENT="@CSC"
 PGP_EMAIL="ega@csc.fi"
 PGP_PASSPHRASE=$(generate_password 16)
+
+RSA_PASSPHRASE=$(generate_password 16)
 
 LOG_LEVEL=INFO

--- a/deployments/docker/bootstrap/settings/swe1
+++ b/deployments/docker/bootstrap/settings/swe1
@@ -4,6 +4,7 @@ set -e
 DOCKER_PORT_inbox=2222
 DOCKER_PORT_mq=15672
 DOCKER_PORT_kibana=5601
+DOCKER_PORT_keyserver=8443
 
 LEGA_GREETINGS="Welcome to Local EGA Sweden @ NBIS"
 CEGA_MQ_PASSWORD=$(generate_password 16)
@@ -19,5 +20,7 @@ PGP_NAME="EGA Sweden"
 PGP_COMMENT="@NBIS"
 PGP_EMAIL="ega@nbis.se"
 PGP_PASSPHRASE=$(generate_password 16)
+
+RSA_PASSPHRASE=$(generate_password 16)
 
 LOG_LEVEL=DEBUG

--- a/deployments/docker/images/Makefile
+++ b/deployments/docker/images/Makefile
@@ -20,7 +20,7 @@ TARGET=nbisweden/ega
 
 all: base inbox
 
-base: PIP_EGA_PACKAGES=pika==0.11.0 pycryptodomex==3.4.7 psycopg2==2.7.4 cryptography==2.1.3 aiohttp==2.3.8 aiohttp-jinja2==0.13.0 pgpy fusepy
+base: PIP_EGA_PACKAGES=pika==0.11.0 pycryptodomex==3.4.7 psycopg2==2.7.4 cryptography==2.1.3 aiohttp==2.3.8 aiohttp-jinja2==0.13.0 pgpy fusepy aiopg==0.13.0
 base inbox:
 	docker build --build-arg checkout=$(CHECKOUT) \
                      --build-arg PIP_EGA_PACKAGES="$(PIP_EGA_PACKAGES)" \

--- a/extras/db.sql
+++ b/extras/db.sql
@@ -21,6 +21,7 @@ CREATE TABLE files (
 	status         status,
 	staging_name   TEXT,
 	stable_id      TEXT,
+	filepath       TEXT,
 	reenc_info     TEXT,
 	reenc_size     INTEGER,
 	reenc_checksum TEXT, -- sha256
@@ -30,18 +31,30 @@ CREATE TABLE files (
 
 CREATE FUNCTION insert_file(filename    files.filename%TYPE,
 			    eid         files.elixir_id%TYPE,
+			    stable_id   files.stable_id%TYPE,
 			    status      files.status%TYPE)
     RETURNS files.id%TYPE AS $insert_file$
     #variable_conflict use_column
     DECLARE
         file_id files.id%TYPE;
     BEGIN
-	INSERT INTO files (filename,elixir_id,status)
-	VALUES(filename,eid,status) RETURNING files.id
+	INSERT INTO files (filename,elixir_id,stable_id,status)
+	VALUES(filename,eid,stable_id,status) RETURNING files.id
 	INTO file_id;
 	RETURN file_id;
     END;
 $insert_file$ LANGUAGE plpgsql;
+
+CREATE FUNCTION translate_fileid_to_filepath(sid files.stable_id%TYPE)
+    RETURNS files.filepath%TYPE AS $translate_fileid_to_filepath$
+    #variable_conflict use_column
+    DECLARE
+        filepath files.filepath%TYPE;
+    BEGIN
+	SELECT filepath FROM files WHERE stable_id = sid LIMIT 1 INTO filepath;
+	RETURN filepath;
+    END;
+$translate_fileid_to_filepath$ LANGUAGE plpgsql;
 
 -- ##################################################
 --                      ERRORS

--- a/extras/publish.py
+++ b/extras/publish.py
@@ -28,13 +28,17 @@ enc_group.add_argument('--enc_algo', default='md5', help='[Default: md5]')
 
 args = parser.parse_args()
 
-message = { 'user': args.user, 'filepath': args.filepath }
+stable_id = 'EGAF_'+str(uuid.uuid4())
+
+print('Ingesting file',stable_id)
+
+message = { 'user': args.user, 'filepath': args.filepath, 'stable_id': stable_id }
 if args.enc:
     message['encrypted_integrity'] = { 'checksum': args.enc, 'algorithm': args.enc_algo, }
 if args.unenc:
     message['unencrypted_integrity'] = { 'checksum': args.unenc, 'algorithm': args.unenc_algo, }
 
-print('Publishing:',message)
+#print('Publishing:',message)
 
 parameters = pika.URLParameters(args.connection)
 connection = pika.BlockingConnection(parameters)
@@ -44,4 +48,4 @@ channel.basic_publish(exchange='localega.v1', routing_key='files',
                       properties=pika.BasicProperties(correlation_id=str(uuid.uuid4()), content_type='application/json',delivery_mode=2))
 
 connection.close()
-print('Message published')
+print('Message published to CentralEGA')

--- a/lega/conf/defaults.ini
+++ b/lega/conf/defaults.ini
@@ -44,3 +44,4 @@ ssl_certfile = /etc/ega/ssl.cert
 ssl_keyfile = /etc/ega/ssl.key
 host = 0.0.0.0
 port = 443
+eureka_endpoint = https://eureka.eu/register/service

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -52,13 +52,14 @@ def work(active_master_key, master_pubkey, data):
     '''
 
     filepath = data['filepath']
-    LOG.info(f"Processing {filepath}")
+    stable_id = data['stable_id']
+    LOG.info(f"Processing {filepath} (with stable_id: {stable_id})")
 
     # Use user_id, and not elixir_id
     user_id = sanitize_user_id(data['user'])
     
     # Insert in database
-    file_id = db.insert_file(filepath, user_id)
+    file_id = db.insert_file(filepath, user_id, stable_id)
 
     # early record
     internal_data = {

--- a/lega/openpgp/__main__.py
+++ b/lega/openpgp/__main__.py
@@ -26,10 +26,8 @@ def fetch_private_key(key_id):
         LOG.info('Opening connection to %s', keyurl)
         with urlopen(req, context=ssl_ctx) as response:
             data = json.loads(response.read().decode())
-            public_key_material = bytes.fromhex(data['public'])
-            private_key_material = bytes.fromhex(data['private'])
         LOG.info('Connection to the server closed for %s', key_id)
-        return make_key(public_key_material, private_key_material)
+        return make_key(data)
     except HTTPError as e:
         LOG.critical('Unknown PGP key %s', key_id)
         sys.exit(1)

--- a/lega/openpgp/packet.py
+++ b/lega/openpgp/packet.py
@@ -10,7 +10,7 @@ from .constants import lookup_pub_algorithm, lookup_sym_algorithm, lookup_hash_a
 from .utils import (PGPError,
                     read_1_byte, read_2_bytes, read_4_bytes,
                     new_tag_length, old_tag_length,
-                    get_mpi, parse_public_key_material, parse_private_key_material,
+                    get_mpi, parse_public_key_material, parse_private_key_material, pack_key_material,
                     derive_key,
                     decryptor, make_decryptor,
                     decompressor,
@@ -289,7 +289,9 @@ class SecretKeyPacket(PublicKeyPacket):
         
         validate_private_data(clear_private_data, self.s2k_usage)
         LOG.info('Passphrase correct')
-        return (self.public_part.getvalue(), clear_private_data)
+
+        # Packing the return data
+        return pack_key_material(self.public_part, io.BytesIO(clear_private_data))
 
     def __repr__(self):
         s = super().__repr__()

--- a/lega/openpgp/utils.py
+++ b/lega/openpgp/utils.py
@@ -348,11 +348,11 @@ def parse_private_key_material(raw_pub_algorithm, data, buf=None):
     elif raw_pub_algorithm == 17:
         # x
         x = get_mpi(data, buf=buf)
-        return x
+        return (x, )
     elif raw_pub_algorithm in (16, 20):
         # x
         x = get_mpi(data, buf=buf)
-        return x
+        return (x, )
     elif 100 <= raw_pub_algorithm <= 110:
         # Private/Experimental algorithms, just move on
         raise PGPError(f"Experimental private key part: {raw_pub_algorithm}")

--- a/lega/openpgp/utils.py
+++ b/lega/openpgp/utils.py
@@ -384,10 +384,10 @@ def pack_key_material(pub_stream, priv_stream):
         material_keys_priv = ('d','p','q','u')
     elif key_type == "dsa":
         material_keys_pub = ('p','q','g','y')
-        material_keys_priv = ('x')
+        material_keys_priv = ('x', )
     elif key_type == "elg":
         material_keys_pub = ('p','g','y')
-        material_keys_priv = ('x')
+        material_keys_priv = ('x', )
     else:
         raise PGPError(f'Cannot pack a "{key_material}" key material')
 

--- a/lega/verify.py
+++ b/lega/verify.py
@@ -30,12 +30,12 @@ def work(data):
     LOG.debug(f'Verifying message: {data}')
 
     file_id = data.pop('internal_data') # can raise KeyError
-    filename, _, org_hash_algo, vault_filename, vault_checksum = db.get_details(file_id)
+    filename, _, org_hash_algo, vault_filename, stable_id, vault_checksum = db.get_details(file_id)
 
     if not checksum.is_valid(vault_filename, vault_checksum, hashAlgo='sha256'):
         raise exceptions.VaultDecryption(vault_filename)
 
-    data['status'] = { 'state': 'COMPLETED', 'details': file_id }
+    data['status'] = { 'state': 'COMPLETED', 'details': stable_id }
     return data
 
 def main(args=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pika==0.11.0
 colorama==0.3.7
-aiohttp==2.3.8
+aiohttp==3.0.7
 aiohttp-jinja2==0.13.0
 fusepy
 sphinx_rtd_theme
@@ -8,3 +8,4 @@ pycryptodomex==3.4.7
 cryptography==2.1.3
 pgpy
 psycopg2==2.7.4
+aiopg==0.13.0

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ Users are handled throught Central EGA, directly.
       #     'pika==0.11.0',
       #     'colorama==0.3.7',
       #     'psycopg2==2.7.4',
+      #     'aiopg'==0.13.0,
       #     'aiohttp==2.3.8',
       #     'aiohttp-jinja2==0.13.0',
       #     'fusepy',

--- a/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
+++ b/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
@@ -222,6 +222,7 @@ public class Utils {
         Message message = new Message();
         message.setUser(user);
         message.setFilepath(filepath);
+	message.setStableID("EGAF_" + UUID.randomUUID().toString());
 
         Checksum unencrypted = new Checksum();
         unencrypted.setAlgorithm("md5");

--- a/tests/src/test/java/se/nbis/lega/cucumber/publisher/Message.java
+++ b/tests/src/test/java/se/nbis/lega/cucumber/publisher/Message.java
@@ -14,6 +14,9 @@ public class Message {
   @JsonProperty("filepath")
   private String filepath;
 
+  @JsonProperty("stable_id")
+  private String stableID;
+
   @JsonProperty("encrypted_integrity")
   private Checksum encryptedIntegrity;
 

--- a/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
+++ b/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
@@ -55,7 +55,7 @@ public class Ingestion implements En {
         Then("^the file is ingested successfully$", () -> {
             try {
                 String output = utils.executeDBQuery(context.getTargetInstance(),
-                        String.format("select stable_id from files where filename = '%s'", context.getEncryptedFile().getName()));
+                        String.format("select filepath from files where filename = '%s'", context.getEncryptedFile().getName()));
                 String vaultFileName = output.split(System.getProperty("line.separator"))[2].trim();
                 String cat = utils.executeWithinContainer(utils.findContainer(utils.getProperty("images.name.vault"),
                         utils.getProperty("container.prefix.vault") + context.getTargetInstance()), "cat", vaultFileName);
@@ -69,7 +69,7 @@ public class Ingestion implements En {
         Then("^ingestion failed$", () -> {
             try {
                 String output = utils.executeDBQuery(context.getTargetInstance(),
-                        String.format("select stable_id from files where filename = '%s'", context.getEncryptedFile().getName()));
+                        String.format("select filepath from files where filename = '%s'", context.getEncryptedFile().getName()));
                 String vaultFileName = output.split(System.getProperty("line.separator"))[2].trim();
                 Assertions.assertThat(vaultFileName).isEmpty();
             } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
CentralEGA uses their own IDs to identify files. These IDs are assumed unique and we receive them in the broker message.

We only add them to our database for information. For each EGA-id, we internally use another locally managed _unique_ ID.

We add in this PR, an endpoint to translate the EGA-id into a vault filepath. The endpoint is temporarily added to the keyserver, since the data-out-api is already accessing it. This will not be the case in the future.