### PR TITLE
Missing readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,9 @@
+formats:
+    - none
+build:
+    image: latest
+python:
+   version: 3.6
+   setup_py_install: False
+   extra_requirements:
+        - docs


### PR DESCRIPTION
The `readthedocs.yml` file is missing and docs build fails http://readthedocs.org/projects/localega/builds/
Adding the file should fix it, latest working build was http://readthedocs.org/projects/localega/builds/6984347/
@silverdaz could you check that docs are built, after adding this file.