### PR TITLE
Adding support for env variables

### DIFF
--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -88,14 +88,7 @@ cat > ${PRIVATE}/${INSTANCE}/ega.conf <<EOF
 [DEFAULT]
 log = /etc/ega/logger.yml
 
-[keyserver]
-port = 8443
-
-[ingestion]
-# Keyserver communication
-keyserver_endpoint_pgp = http://ega-keys-${INSTANCE}:8443/retrieve/pgp/%s
-keyserver_endpoint_rsa = http://ega-keys-${INSTANCE}:8443/active/rsa
-
+[inbox]
 decrypt_cmd = python3.6 -u -m lega.openpgp %(file)s
 
 [outgestion]

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -153,37 +153,12 @@ root:
   handlers: [noHandler]
 
 loggers:
-  connect:
-    level: ${_LOG_LEVEL}
+  lega:
+    level: INFO
     handlers: [logstash,console]
-  ingestion:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  keyserver:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  vault:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  verify:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
+    propagate: true
+    qualname: lega
   socket-utils:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  inbox:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  utils:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  amqp:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  db:
-    level: ${_LOG_LEVEL}
-    handlers: [logstash,console]
-  crypto:
     level: ${_LOG_LEVEL}
     handlers: [logstash,console]
   asyncio:

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -88,7 +88,7 @@ cat > ${PRIVATE}/${INSTANCE}/ega.conf <<EOF
 [DEFAULT]
 log = /etc/ega/logger.yml
 
-[inbox]
+[ingestion]
 decrypt_cmd = python3.6 -u -m lega.openpgp %(file)s
 
 [outgestion]
@@ -110,7 +110,6 @@ try = ${DB_TRY}
 port = 8443
 endpoint_pgp = http://ega-keys-${INSTANCE}:8443/retrieve/pgp/%s
 endpoint_rsa = http://ega-keys-${INSTANCE}:8443/active/rsa
-
 
 [eureka]
 endpoint = http://cega-eureka:8761

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -440,17 +440,6 @@ services:
       - lega_${INSTANCE}
     entrypoint: ["/bin/bash", "/usr/local/bin/entrypoint.sh"]
 
-  # Config server
-  config-${INSTANCE}:
-    hostname: ega-config-${INSTANCE}
-    container_name: ega-config-${INSTANCE}
-    image: nbisweden/ega-config
-    ports:
-      - "${DOCKER_PORT_config}:8888"
-    restart: on-failure:3
-    networks:
-      - lega_${INSTANCE}
-
   # Key server
   keys-${INSTANCE}:
     env_file: ${INSTANCE}/pgp.env

--- a/deployments/docker/bootstrap/instance.sh
+++ b/deployments/docker/bootstrap/instance.sh
@@ -88,11 +88,7 @@ cat > ${PRIVATE}/${INSTANCE}/ega.conf <<EOF
 [DEFAULT]
 log = /etc/ega/logger.yml
 
-[ingestion]
-# Keyserver communication
-keyserver_endpoint_pgp = http://ega-keys-${INSTANCE}:443/retrieve/pgp/%s
-keyserver_endpoint_rsa = http://ega-keys-${INSTANCE}:443/active/rsa
-
+[inbox]
 decrypt_cmd = python3.6 -u -m lega.openpgp %(file)s
 
 [outgestion]
@@ -103,11 +99,17 @@ keyserver_endpoint = https://ega-keys-${INSTANCE}:443/temp/file/%s
 [broker]
 host = ega-mq-${INSTANCE}
 
-[db]
+[postgres]
 host = ega-db-${INSTANCE}
-username = ${DB_USER}
+user = ${DB_USER}
 password = ${DB_PASSWORD}
 try = ${DB_TRY}
+
+[keyserver]
+# Keyserver communication
+endpoint_pgp = http://ega-keys-${INSTANCE}:443/retrieve/pgp/%s
+endpoint_rsa = http://ega-keys-${INSTANCE}:443/active/rsa
+
 
 [eureka]
 endpoint = http://cega-eureka:8761
@@ -437,6 +439,17 @@ services:
     networks:
       - lega_${INSTANCE}
     entrypoint: ["/bin/bash", "/usr/local/bin/entrypoint.sh"]
+
+  # Config server
+  config-${INSTANCE}:
+    hostname: ega-config-${INSTANCE}
+    container_name: ega-config-${INSTANCE}
+    image: nbisweden/ega-config
+    ports:
+      - "${DOCKER_PORT_config}:8888"
+    restart: on-failure:3
+    networks:
+      - lega_${INSTANCE}
 
   # Key server
   keys-${INSTANCE}:

--- a/deployments/docker/images/vault/entrypoint.sh
+++ b/deployments/docker/images/vault/entrypoint.sh
@@ -15,7 +15,7 @@ echo "Waiting for Local Message Broker"
 until nc -4 --send-only ${MQ_INSTANCE} 5672 </dev/null &>/dev/null; do sleep 1; done
 
 echo "Starting the verifier"
-ega-verify &
+gosu lega ega-verify &
 
 echo "Starting the vault listener"
 exec gosu lega ega-vault

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -38,6 +38,8 @@ using the ``--conf <file>`` switch to specify the configuration file.
 
 The settings are loaded, in order:
 
+* from environment variables (the naming convetion is according to
+  ``default.ini`` where ``section`` and ``option``, both uppercased e.g. ``KEYSERVER_ENDPOINT_PGP`` or ``POSTGRES_DB``);
 * from the package's ``defaults.ini``
 * from the file ``/etc/ega/conf.ini`` (if it exists)
 * and finally from the file specified as the ``--conf`` argument.

--- a/lega/conf/__init__.py
+++ b/lega/conf/__init__.py
@@ -39,8 +39,6 @@ class Configuration(configparser.ConfigParser):
     """Configuration from config_files or environment variables or config server (e.g. Spring Cloud Config)."""
 
     log_conf = None
-    BOOLEAN_STATES = {'1': True, 'yes': True, 'true': True, 'on': True,
-                      '0': False, 'no': False, 'false': False, 'off': False}
 
     def _load_conf(self, args=None, encoding='utf-8'):
         """Load a configuration file from `args`."""
@@ -134,8 +132,14 @@ class Configuration(configparser.ConfigParser):
             return self._convert(self.get(section, option, fallback=default_value, raw=raw), conv)
 
     def _convert(self, value, conv):
-        if conv == bool and value.lower() in self.BOOLEAN_STATES:
-            return self.BOOLEAN_STATES[value.lower()]
+        if conv == bool:
+            val = value.lower()
+            if val in ('y', 'yes', 't', 'true', 'on', '1'):
+                return True
+            elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+                return False
+            else:
+                raise ValueError(f"Invalid truth value: {val}")
         else:
             return conv(value)
 

--- a/lega/conf/__init__.py
+++ b/lega/conf/__init__.py
@@ -124,14 +124,19 @@ class Configuration(configparser.ConfigParser):
             res += '\nLogging settings loaded from ' + str(self.log_conf)
         return res
 
-    def get_value(self, section, option, conv=str, default_value=None, raw=False):
+    def get_value(self, section, option, conv=str, default=None, raw=False):
+        """"Get a specific value for this paramater either as env variable or from config files.
+
+        ``section`` and ``option`` are mandatory while ``conv``, ``default`` (fallback) and ``raw`` are optional.
+        """
         result = os.environ.get('_'.join([section.upper(), option.upper()]), None)
         if result:
             return self._convert(result, conv)
         elif result is None and self.has_option(section, option):
-            return self._convert(self.get(section, option, fallback=default_value, raw=raw), conv)
+            return self._convert(self.get(section, option, fallback=default, raw=raw), conv)
 
     def _convert(self, value, conv):
+        """Convert value properly to ``str``, ``float`` or ``int``, also consider ``bool`` type."""
         if conv == bool:
             val = value.lower()
             if val in ('y', 'yes', 't', 'true', 'on', '1'):

--- a/lega/conf/defaults.ini
+++ b/lega/conf/defaults.ini
@@ -2,24 +2,19 @@
 # log = /path/to/logger.yml or keyword (like 'default', 'debug', 'logstash', 'silent')
 log = nope
 
-[frontend]
-host = ega_frontend
-port = 80
-cega_password = password
-
-[ingestion]
+[inbox]
 # Keyserver communication
-keyserver_endpoint_pgp = https://ega-keys/retrieve/pgp/%s
-keyserver_endpoint_rsa = https://ega-keys/active/rsa
+# keyserver_endpoint_pgp = https://ega-keys/retrieve/pgp/%s
+# keyserver_endpoint_rsa = https://ega-keys/active/rsa
 
-inbox = /ega/inbox/%(user_id)s
+path = /ega/inbox/%(user_id)s
 staging = /ega/staging
 
 #decrypt_cmd = gpg --decrypt %(file)s
 decrypt_cmd = python -u -m lega.openpgp %(file)s
 
 [vault]
-location = /ega/vault
+path = /ega/vault
 
 ## Connecting to Local Broker
 [broker]
@@ -32,14 +27,18 @@ vhost = /
 connection_attempts = 2
 heartbeat = 0
 
-[db]
+[postgres]
 host = localhost
 port = 5432
-username = admin
+user = admin
 password = secret
-dbname = lega
+db = lega
+try = 1
+try_interval = 1
 
 [keyserver]
+endpoint_pgp = https://ega-keys/retrieve/pgp/%s
+endpoint_rsa = https://ega-keys/active/rsa
 ssl_certfile = /etc/ega/ssl.cert
 ssl_keyfile = /etc/ega/ssl.key
 host = 0.0.0.0

--- a/lega/conf/defaults.ini
+++ b/lega/conf/defaults.ini
@@ -2,7 +2,7 @@
 # log = /path/to/logger.yml or keyword (like 'default', 'debug', 'logstash', 'silent')
 log = nope
 
-[inbox]
+[ingestion]
 path = /ega/inbox/%(user_id)s
 staging = /ega/staging
 

--- a/lega/conf/defaults.ini
+++ b/lega/conf/defaults.ini
@@ -3,10 +3,6 @@
 log = nope
 
 [inbox]
-# Keyserver communication
-# keyserver_endpoint_pgp = https://ega-keys/retrieve/pgp/%s
-# keyserver_endpoint_rsa = https://ega-keys/active/rsa
-
 path = /ega/inbox/%(user_id)s
 staging = /ega/staging
 

--- a/lega/conf/loggers/logger.yml
+++ b/lega/conf/loggers/logger.yml
@@ -4,39 +4,11 @@ root:
   handlers: [noHandler]
 
 loggers:
-  connect:
+  lega:
     level: INFO
     handlers: [console]
-  ingestion:
-    level: INFO
-    handlers: [console]
-  keyserver:
-    level: INFO
-    handlers: [console]
-  vault:
-    level: INFO
-    handlers: [console]
-  verify:
-    level: INFO
-    handlers: [console]
-  socket-utils:
-    level: INFO
-    handlers: [console]
-  inbox:
-    level: INFO
-    handlers: [console]
-  utils:
-    level: INFO
-    handlers: [console]
-  amqp:
-    level: INFO
-    handlers: [console]
-  db:
-    level: INFO
-    handlers: [console]
-  crypto:
-    level: INFO
-    handlers: [console]
+    propagate: true
+    qualname: lega
   asyncio:
     level: INFO
     handlers: [console]

--- a/lega/conf/loggers/logger.yml
+++ b/lega/conf/loggers/logger.yml
@@ -1,0 +1,85 @@
+version: 1
+root:
+  level: NOTSET
+  handlers: [noHandler]
+
+loggers:
+  connect:
+    level: INFO
+    handlers: [console]
+  ingestion:
+    level: INFO
+    handlers: [console]
+  keyserver:
+    level: INFO
+    handlers: [console]
+  vault:
+    level: INFO
+    handlers: [console]
+  verify:
+    level: INFO
+    handlers: [console]
+  socket-utils:
+    level: INFO
+    handlers: [console]
+  inbox:
+    level: INFO
+    handlers: [console]
+  utils:
+    level: INFO
+    handlers: [console]
+  amqp:
+    level: INFO
+    handlers: [console]
+  db:
+    level: INFO
+    handlers: [console]
+  crypto:
+    level: INFO
+    handlers: [console]
+  asyncio:
+    level: INFO
+    handlers: [console]
+  aiopg:
+    level: INFO
+    handlers: [console]
+  aiohttp.access:
+    level: INFO
+    handlers: [console]
+  aiohttp.client:
+    level: INFO
+    handlers: [console]
+  aiohttp.internal:
+    level: INFO
+    handlers: [console]
+  aiohttp.server:
+    level: INFO
+    handlers: [console]
+  aiohttp.web:
+    level: INFO
+    handlers: [console]
+  aiohttp.websocket:
+    level: INFO
+    handlers: [console]
+
+
+handlers:
+  noHandler:
+    class: logging.NullHandler
+    level: NOTSET
+  console:
+    class: logging.StreamHandler
+    formatter: simple
+    stream: ext://sys.stdout
+
+formatters:
+  json:
+    (): lega.utils.logging.JSONFormatter
+    format: '(asctime) (name) (process) (processName) (levelname) (lineno) (funcName) (message)'
+  lega:
+    format: '[{asctime:<20}][{name}][{process:d} {processName:>15}][{levelname}] (L:{lineno}) {funcName}: {message}'
+    style: '{'
+    datefmt: '%Y-%m-%d %H:%M:%S'
+  simple:
+    format: '[{name:^10}][{levelname:^6}] (L{lineno}) {message}'
+    style: '{'

--- a/lega/fs.py
+++ b/lega/fs.py
@@ -28,7 +28,7 @@ from .conf import CONF
 from .utils.amqp import get_connection, publish
 from .utils.checksum import calculate, _DIGEST as algorithms
 
-LOG = logging.getLogger('inbox')
+LOG = logging.getLogger(__name__)
 
 ATTRIBUTES = ('st_uid', 'st_gid', 'st_mode', 'st_size',
               'st_nlink', 'st_atime', 'st_ctime', 'st_mtime')

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -71,7 +71,7 @@ def work(master_key, data):
     data['internal_data'] = internal_data
 
     # Find inbox
-    inbox = Path(CONF.get_value('inbox', 'path', raw=True) % {'user_id': user_id})
+    inbox = Path(CONF.get_value('ingestion', 'path', raw=True) % {'user_id': user_id})
     LOG.info(f"Inbox area: {inbox}")
 
     # Check if file is in inbox
@@ -119,7 +119,7 @@ def work(master_key, data):
                                          'algorithm': unencrypted_algo }
 
     # Fetch staging area
-    staging_area = Path(CONF.get_value('inbox', 'staging'))
+    staging_area = Path(CONF.get_value('ingestion', 'staging'))
     LOG.info(f"Staging area: {staging_area}")
     #staging_area.mkdir(parents=True, exist_ok=True) # re-create
 
@@ -139,7 +139,7 @@ def work(master_key, data):
     publish(data, broker.channel(), 'cega', 'files.processing')
 
     # Decrypting
-    cmd = CONF.get_value('inbox', 'decrypt_cmd', raw=True) % {'file': str(inbox_filepath)}
+    cmd = CONF.get_value('ingestion', 'decrypt_cmd', raw=True) % {'file': str(inbox_filepath)}
     LOG.debug(f'GPG command: {cmd}\n')
     details, staging_checksum = crypto_ingest( cmd,
                                                str(inbox_filepath),

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -59,7 +59,7 @@ def work(master_key, data):
 
     # Use user_id, and not elixir_id
     user_id = sanitize_user_id(data['user'])
-    
+
     # Insert in database
     file_id = db.insert_file(filepath, user_id, stable_id)
 
@@ -71,7 +71,7 @@ def work(master_key, data):
     data['internal_data'] = internal_data
 
     # Find inbox
-    inbox = Path( CONF.get('ingestion','inbox',raw=True) % { 'user_id': user_id } )
+    inbox = Path(CONF.get_or_else('inbox', 'path', raw=True) % {'user_id': user_id})
     LOG.info(f"Inbox area: {inbox}")
 
     # Check if file is in inbox
@@ -97,7 +97,7 @@ def work(master_key, data):
 
     assert( isinstance(encrypted_hash,str) )
     assert( isinstance(encrypted_algo,str) )
-    
+
     # Check integrity of encrypted file
     LOG.debug(f"Verifying the {encrypted_algo} checksum of encrypted file: {inbox_filepath}")
     if not checksum.is_valid(inbox_filepath, encrypted_hash, hashAlgo = encrypted_algo):
@@ -119,10 +119,10 @@ def work(master_key, data):
                                          'algorithm': unencrypted_algo }
 
     # Fetch staging area
-    staging_area = Path( CONF.get('ingestion','staging') )
+    staging_area = Path(CONF.get_or_else('inbox', 'staging'))
     LOG.info(f"Staging area: {staging_area}")
     #staging_area.mkdir(parents=True, exist_ok=True) # re-create
-        
+
     # Create a unique name for the staging area
     unique_name = str(uuid.uuid5(uuid.NAMESPACE_OID, 'lega'))
     LOG.debug(f'Created an unique filename in the staging area: {unique_name}')
@@ -139,7 +139,7 @@ def work(master_key, data):
     publish(data, broker.channel(), 'cega', 'files.processing')
 
     # Decrypting
-    cmd = CONF.get('ingestion','decrypt_cmd',raw=True) % { 'file': str(inbox_filepath) }
+    cmd = CONF.get_or_else('inbox', 'decrypt_cmd', raw=True) % {'file': str(inbox_filepath)}
     LOG.debug(f'GPG command: {cmd}\n')
     details, staging_checksum = crypto_ingest( cmd,
                                                str(inbox_filepath),
@@ -149,13 +149,14 @@ def work(master_key, data):
                                                target = staging_filepath)
     db.set_encryption(file_id, details, staging_checksum)
     LOG.debug(f'Re-encryption completed')
-    
+
     internal_data['filepath'] = str(staging_filepath)
     LOG.debug(f"Reply message: {data}")
     return data
 
+
 def get_master_key():
-    keyurl = CONF.get('ingestion','keyserver_endpoint_rsa')
+    keyurl = CONF.get_or_else('keyserver', 'endpoint_rsa')
     LOG.info(f'Retrieving the Master Public Key from {keyurl}')
     try:
         # Prepare to contact the Keyserver for the Master key
@@ -178,7 +179,7 @@ def main(args=None):
     LOG.info(f"Master Key ID: {master_key['id']}")
     LOG.debug(f"Master Key: {master_key}")
     do_work = partial(work, master_key)
-        
+
     # upstream link configured in local broker
     consume(do_work, 'files', 'staged')
 

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -37,7 +37,7 @@ from .utils import db, exceptions, checksum, sanitize_user_id
 from .utils.amqp import consume, publish, get_connection
 from .utils.crypto import ingest as crypto_ingest
 
-LOG = logging.getLogger('ingestion')
+LOG = logging.getLogger(__name__)
 
 @db.catch_error
 def work(master_key, data):
@@ -71,7 +71,7 @@ def work(master_key, data):
     data['internal_data'] = internal_data
 
     # Find inbox
-    inbox = Path(CONF.get_or_else('inbox', 'path', raw=True) % {'user_id': user_id})
+    inbox = Path(CONF.get_value('inbox', 'path', raw=True) % {'user_id': user_id})
     LOG.info(f"Inbox area: {inbox}")
 
     # Check if file is in inbox
@@ -119,7 +119,7 @@ def work(master_key, data):
                                          'algorithm': unencrypted_algo }
 
     # Fetch staging area
-    staging_area = Path(CONF.get_or_else('inbox', 'staging'))
+    staging_area = Path(CONF.get_value('inbox', 'staging'))
     LOG.info(f"Staging area: {staging_area}")
     #staging_area.mkdir(parents=True, exist_ok=True) # re-create
 
@@ -139,7 +139,7 @@ def work(master_key, data):
     publish(data, broker.channel(), 'cega', 'files.processing')
 
     # Decrypting
-    cmd = CONF.get_or_else('inbox', 'decrypt_cmd', raw=True) % {'file': str(inbox_filepath)}
+    cmd = CONF.get_value('inbox', 'decrypt_cmd', raw=True) % {'file': str(inbox_filepath)}
     LOG.debug(f'GPG command: {cmd}\n')
     details, staging_checksum = crypto_ingest( cmd,
                                                str(inbox_filepath),
@@ -156,7 +156,7 @@ def work(master_key, data):
 
 
 def get_master_key():
-    keyurl = CONF.get_or_else('keyserver', 'endpoint_rsa')
+    keyurl = CONF.get_value('keyserver', 'endpoint_rsa')
     LOG.info(f'Retrieving the Master Public Key from {keyurl}')
     try:
         # Prepare to contact the Keyserver for the Master key

--- a/lega/keyserver.py
+++ b/lega/keyserver.py
@@ -171,7 +171,7 @@ async def activate_key(key_name, data):
     elif key_name.startswith("rsa"):
         obj_key = ReEncryptionKey(key_name, data.get('path'), data.get('passphrase',None))
         _cache = _rsa_cache
-        
+
         ### Temporary
         with open(data.get('path'), 'rb') as infile:
             _tmp_cache.set(key_name,
@@ -508,15 +508,15 @@ def main(args=None):
 
     CONF.setup(args)
 
-    host = CONF.get('keyserver', 'host') # fallbacks are in defaults.ini
-    port = CONF.getint('keyserver', 'port')
-    keyserver_health = CONF.get('keyserver', 'health_endpoint')
-    keyserver_status = CONF.get('keyserver', 'status_endpoint')
+    host = CONF.get_or_else('keyserver', 'host')  # fallbacks are in defaults.ini
+    port = CONF.getint_or_else('keyserver', 'port')
+    keyserver_health = CONF.get_or_else('keyserver', 'health_endpoint')
+    keyserver_status = CONF.get_or_else('keyserver', 'status_endpoint')
 
-    eureka_endpoint = CONF.get('eureka', 'endpoint')
+    eureka_endpoint = CONF.get_or_else('eureka', 'endpoint')
 
-    # ssl_certfile = Path(CONF.get('keyserver', 'ssl_certfile')).expanduser()
-    # ssl_keyfile = Path(CONF.get('keyserver', 'ssl_keyfile')).expanduser()
+    # ssl_certfile = Path(CONF.get_or_else('keyserver', 'ssl_certfile')).expanduser()
+    # ssl_keyfile = Path(CONF.get_or_else('keyserver', 'ssl_keyfile')).expanduser()
     # LOG.debug(f'Certfile: {ssl_certfile}')
     # LOG.debug(f'Keyfile: {ssl_keyfile}')
 
@@ -533,7 +533,7 @@ def main(args=None):
 
     # Adding the keystore to the server
     keyserver['store'] = KeysConfiguration(args)
-    keyserver['interval'] = CONF.getint('eureka', 'interval')
+    keyserver['interval'] = CONF.getint_or_else('eureka', 'interval')
     keyserver['eureka'] = EurekaClient("keyserver", port=port, ip_addr=host,
                                        eureka_url=eureka_endpoint, hostname=host,
                                        health_check_url=f'http://{host}:{port}{keyserver_health}',

--- a/lega/keyserver.py
+++ b/lega/keyserver.py
@@ -24,7 +24,7 @@ from .utils.crypto import get_rsa_private_key_material, serialize_rsa_private_ke
 # from .openpgp.generate import generate_pgp_key
 from .utils.eureka import EurekaClient
 
-LOG = logging.getLogger('keyserver')
+LOG = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
 class Cache:
@@ -508,15 +508,15 @@ def main(args=None):
 
     CONF.setup(args)
 
-    host = CONF.get_or_else('keyserver', 'host')  # fallbacks are in defaults.ini
-    port = CONF.getint_or_else('keyserver', 'port')
-    keyserver_health = CONF.get_or_else('keyserver', 'health_endpoint')
-    keyserver_status = CONF.get_or_else('keyserver', 'status_endpoint')
+    host = CONF.get_value('keyserver', 'host')  # fallbacks are in defaults.ini
+    port = CONF.get_value('keyserver', 'port', int)
+    keyserver_health = CONF.get_value('keyserver', 'health_endpoint')
+    keyserver_status = CONF.get_value('keyserver', 'status_endpoint')
 
-    eureka_endpoint = CONF.get_or_else('eureka', 'endpoint')
+    eureka_endpoint = CONF.get_value('eureka', 'endpoint')
 
-    # ssl_certfile = Path(CONF.get_or_else('keyserver', 'ssl_certfile')).expanduser()
-    # ssl_keyfile = Path(CONF.get_or_else('keyserver', 'ssl_keyfile')).expanduser()
+    # ssl_certfile = Path(CONF.get_value('keyserver', 'ssl_certfile')).expanduser()
+    # ssl_keyfile = Path(CONF.get_value('keyserver', 'ssl_keyfile')).expanduser()
     # LOG.debug(f'Certfile: {ssl_certfile}')
     # LOG.debug(f'Keyfile: {ssl_keyfile}')
 
@@ -533,7 +533,7 @@ def main(args=None):
 
     # Adding the keystore to the server
     keyserver['store'] = KeysConfiguration(args)
-    keyserver['interval'] = CONF.getint_or_else('eureka', 'interval')
+    keyserver['interval'] = CONF.get_value('eureka', 'interval', int)
     keyserver['eureka'] = EurekaClient("keyserver", port=port, ip_addr=host,
                                        eureka_url=eureka_endpoint, hostname=host,
                                        health_check_url=f'http://{host}:{port}{keyserver_health}',

--- a/lega/keyserver.py
+++ b/lega/keyserver.py
@@ -509,7 +509,7 @@ def main(args=None):
     CONF.setup(args)
 
     host = CONF.get_value('keyserver', 'host')  # fallbacks are in defaults.ini
-    port = CONF.get_value('keyserver', 'port', int)
+    port = CONF.get_value('keyserver', 'port', conv=int)
     keyserver_health = CONF.get_value('keyserver', 'health_endpoint')
     keyserver_status = CONF.get_value('keyserver', 'status_endpoint')
 
@@ -533,7 +533,7 @@ def main(args=None):
 
     # Adding the keystore to the server
     keyserver['store'] = KeysConfiguration(args)
-    keyserver['interval'] = CONF.get_value('eureka', 'interval', int)
+    keyserver['interval'] = CONF.get_value('eureka', 'interval', conv=int)
     keyserver['eureka'] = EurekaClient("keyserver", port=port, ip_addr=host,
                                        eureka_url=eureka_endpoint, hostname=host,
                                        health_check_url=f'http://{host}:{port}{keyserver_health}',

--- a/lega/openpgp/__main__.py
+++ b/lega/openpgp/__main__.py
@@ -13,15 +13,15 @@ from ..conf import CONF
 from .packet import iter_packets
 from .utils import make_key, PGPError
 
-LOG = logging.getLogger('openpgp')
+LOG = logging.getLogger(__name__)
 
 def fetch_private_key(key_id):
     ssl_ctx = ssl.create_default_context()
     ssl_ctx.check_hostname = False
     ssl_ctx.verify_mode=ssl.CERT_NONE
     LOG.info('Retrieving the PGP Private Key %s', key_id)
-    keyurl = CONF.get_or_else('keyserver', 'endpoint_pgp', raw=True) % key_id
-    LOG.info(keyurl)
+    keyurl = CONF.get_value('keyserver', 'endpoint_pgp', raw=True) % key_id
+    LOG.info(f'Keyserver PGP endpoint: {keyurl}')
     try:
         req = Request(keyurl, headers={'content-type':'application/json'}, method='GET')
         LOG.info('Opening connection to %s', keyurl)

--- a/lega/openpgp/__main__.py
+++ b/lega/openpgp/__main__.py
@@ -20,7 +20,8 @@ def fetch_private_key(key_id):
     ssl_ctx.check_hostname = False
     ssl_ctx.verify_mode=ssl.CERT_NONE
     LOG.info('Retrieving the PGP Private Key %s', key_id)
-    keyurl = CONF.get('ingestion','keyserver_endpoint_pgp',raw=True) % key_id
+    keyurl = CONF.get_or_else('keyserver', 'endpoint_pgp', raw=True) % key_id
+    LOG.info(keyurl)
     try:
         req = Request(keyurl, headers={'content-type':'application/json'}, method='GET')
         LOG.info('Opening connection to %s', keyurl)
@@ -76,5 +77,3 @@ def main(args=None):
 
 if __name__ == '__main__':
     main()
-
-

--- a/lega/openpgp/packet.py
+++ b/lega/openpgp/packet.py
@@ -17,7 +17,7 @@ from .utils import (PGPError,
                     validate_private_data)
 from .iobuf import IOBuf
 
-LOG = logging.getLogger('openpgp')
+LOG = logging.getLogger(__name__)
 
 
 PACKET_TYPES = {} # Will be updated below

--- a/lega/openpgp/utils.py
+++ b/lega/openpgp/utils.py
@@ -16,7 +16,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, modes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa, dsa, padding
 
-LOG = logging.getLogger('openpgp')
+LOG = logging.getLogger(__name__)
 
 from .constants import lookup_sym_algorithm
 

--- a/lega/outgest.py
+++ b/lega/outgest.py
@@ -23,11 +23,11 @@ from .conf import CONF
 from .utils import db, checksum
 from .utils.crypto import decrypt_from_vault
 
-LOG = logging.getLogger('outgestion')
+LOG = logging.getLogger(__name__)
 
 
 def get_master_key():
-    keyurl = CONF.get_or_else('keyserver', 'endpoint_rsa')
+    keyurl = CONF.get_value('keyserver', 'endpoint_rsa')
     LOG.info(f'Retrieving the Master Public Key from {keyurl}')
     try:
         # Prepare to contact the Keyserver for the Master key

--- a/lega/outgest.py
+++ b/lega/outgest.py
@@ -25,8 +25,9 @@ from .utils.crypto import decrypt_from_vault
 
 LOG = logging.getLogger('outgestion')
 
+
 def get_master_key():
-    keyurl = CONF.get('ingestion','keyserver_endpoint_rsa')
+    keyurl = CONF.get_or_else('keyserver', 'endpoint_rsa')
     LOG.info(f'Retrieving the Master Public Key from {keyurl}')
     try:
         # Prepare to contact the Keyserver for the Master key
@@ -36,6 +37,7 @@ def get_master_key():
         LOG.error(repr(e))
         LOG.critical('Problem contacting the Keyserver. Ingestion Worker terminated')
         sys.exit(1)
+
 
 def get_info(fileid):
     # put your dirty hands in the database
@@ -65,10 +67,10 @@ def main(args=None):
     LOG.debug(f"Vault path: {filepath}")
 
     # Decrypting
-    with open(filepath,'rb') as infile: #tempfile.TemporaryFile() as outfile, 
+    with open(filepath,'rb') as infile: #tempfile.TemporaryFile() as outfile,
         hasher = checksum.instantiate(org_checksum_algo)
         decrypt_from_vault(infile, master_key, hasher=hasher) # outfile=None
-        
+
         # Check integrity of decrypted file
         if org_checksum != hasher.hexdigest():
             print("Aiiieeee...bummer.... Invalid checksum")

--- a/lega/utils/__init__.py
+++ b/lega/utils/__init__.py
@@ -4,7 +4,7 @@ Utility functions used internally.
 
 import logging
 
-LOG = logging.getLogger('utils')
+LOG = logging.getLogger(__name__)
 
 def get_file_content(f, mode='rb'):
     try:

--- a/lega/utils/amqp.py
+++ b/lega/utils/amqp.py
@@ -23,16 +23,16 @@ def get_connection(domain, blocking=True):
     assert domain in CONF.sections(), "Section not found in config file"
 
     params = {
-        'host': CONF.get_value(domain, 'host', default_value='localhost'),
-        'port': CONF.get_value(domain, 'port', int, default_value=5672),
-        'virtual_host': CONF.get_value(domain, 'vhost', default_value='/'),
+        'host': CONF.get_value(domain, 'host', default='localhost'),
+        'port': CONF.get_value(domain, 'port', conv=int, default=5672),
+        'virtual_host': CONF.get_value(domain, 'vhost', default='/'),
         'credentials': pika.PlainCredentials(
-            CONF.get_value(domain, 'username', default_value='guest'),
-            CONF.get_value(domain, 'password', default_value='guest')
+            CONF.get_value(domain, 'username', default='guest'),
+            CONF.get_value(domain, 'password', default='guest')
         ),
-        'connection_attempts': CONF.get_value(domain, 'connection_attempts', int, default_value=2),
+        'connection_attempts': CONF.get_value(domain, 'connection_attempts', conv=int, default=2),
     }
-    heartbeat = CONF.get_value(domain, 'heartbeat', int, 0)
+    heartbeat = CONF.get_value(domain, 'heartbeat', conv=int, default=0)
     if heartbeat is not None:  # can be 0
         # heartbeat_interval instead of heartbeat like they say in the doc
         # https://pika.readthedocs.io/en/latest/modules/parameters.html#connectionparameters
@@ -40,7 +40,7 @@ def get_connection(domain, blocking=True):
         LOG.debug(f'Setting hearbeat to {heartbeat}')
 
     # SSL configuration
-    if CONF.get_value(domain, 'enable_ssl', bool, False):
+    if CONF.get_value(domain, 'enable_ssl', conv=bool, default=False):
         params['ssl'] = True
         params['ssl_options'] = {
             'ca_certs': CONF.get_value(domain, 'cacert'),

--- a/lega/utils/amqp.py
+++ b/lega/utils/amqp.py
@@ -9,7 +9,7 @@ import uuid
 
 from ..conf import CONF
 
-LOG = logging.getLogger('amqp')
+LOG = logging.getLogger(__name__)
 
 
 def get_connection(domain, blocking=True):
@@ -23,16 +23,16 @@ def get_connection(domain, blocking=True):
     assert domain in CONF.sections(), "Section not found in config file"
 
     params = {
-        'host': CONF.get_or_else(domain, 'host', 'localhost'),
-        'port': CONF.getint_or_else(domain, 'port', 5672),
-        'virtual_host': CONF.get_or_else(domain, 'vhost', '/'),
+        'host': CONF.get_value(domain, 'host', default_value='localhost'),
+        'port': CONF.get_value(domain, 'port', int, default_value=5672),
+        'virtual_host': CONF.get_value(domain, 'vhost', default_value='/'),
         'credentials': pika.PlainCredentials(
-            CONF.get_or_else(domain, 'username', 'guest'),
-            CONF.get_or_else(domain, 'password', 'guest')
+            CONF.get_value(domain, 'username', default_value='guest'),
+            CONF.get_value(domain, 'password', default_value='guest')
         ),
-        'connection_attempts': CONF.getint_or_else(domain, 'connection_attempts', 2),
+        'connection_attempts': CONF.get_value(domain, 'connection_attempts', int, default_value=2),
     }
-    heartbeat = CONF.getint_or_else(domain, 'heartbeat', None)
+    heartbeat = CONF.get_value(domain, 'heartbeat', int, 0)
     if heartbeat is not None:  # can be 0
         # heartbeat_interval instead of heartbeat like they say in the doc
         # https://pika.readthedocs.io/en/latest/modules/parameters.html#connectionparameters
@@ -40,12 +40,12 @@ def get_connection(domain, blocking=True):
         LOG.debug(f'Setting hearbeat to {heartbeat}')
 
     # SSL configuration
-    if CONF.getboolean_or_else(domain, 'enable_ssl', False):
+    if CONF.get_value(domain, 'enable_ssl', bool, False):
         params['ssl'] = True
         params['ssl_options'] = {
-            'ca_certs': CONF.get_or_else(domain, 'cacert'),
-            'certfile': CONF.get_or_else(domain, 'cert'),
-            'keyfile':  CONF.get_or_else(domain, 'keyfile'),
+            'ca_certs': CONF.get_value(domain, 'cacert'),
+            'certfile': CONF.get_value(domain, 'cert'),
+            'keyfile':  CONF.get_value(domain, 'keyfile'),
             'cert_reqs': 2,  # ssl.CERT_REQUIRED is actually <VerifyMode.CERT_REQUIRED: 2>
         }
 

--- a/lega/utils/checksum.py
+++ b/lega/utils/checksum.py
@@ -7,7 +7,7 @@ import hashlib
 
 from .exceptions import UnsupportedHashAlgorithm, CompanionNotFound
 
-LOG = logging.getLogger('utils-checksum')
+LOG = logging.getLogger(__name__)
 
 # Main map
 _DIGEST = {

--- a/lega/utils/crypto.py
+++ b/lega/utils/crypto.py
@@ -20,7 +20,7 @@ from cryptography.hazmat.primitives import serialization
 
 from . import exceptions, checksum
 
-LOG = logging.getLogger('crypto')
+LOG = logging.getLogger(__name__)
 
 ###########################################################
 # RSA Master Key

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -36,15 +36,15 @@ def fetch_args(d):
                 'password' : d.get_value('postgres', 'password'),
                 'database' : d.get_value('postgres', 'db'),
                 'host'     : d.get_value('postgres', 'host'),
-                'port'     : d.get_value('postgres', 'port', int)
+                'port'     : d.get_value('postgres', 'port', conv=int)
     }
     LOG.info(f"Initializing a connection to: {db_args['host']}:{db_args['port']}/{db_args['database']}")
     return db_args
 
 async def _retry(run, on_failure=None, exception=psycopg2.OperationalError):
     '''Main retry loop'''
-    nb_try = CONF.get_value('postgres', 'try', int, 1)
-    try_interval = CONF.get_value('postgres', 'try_interval', int, 1)
+    nb_try = CONF.get_value('postgres', 'try', conv=int, default=1)
+    try_interval = CONF.get_value('postgres', 'try_interval', conv=int, default=1)
     LOG.debug(f"{nb_try} attempts (every {try_interval} seconds)")
     count = 0
     backoff = try_interval

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -34,7 +34,7 @@ class Status(Enum):
 def fetch_args(d):
     db_args = { 'user'     : d.get_value('postgres', 'user'),
                 'password' : d.get_value('postgres', 'password'),
-                'database' : d.get_value('postgres', 'dbname'),
+                'database' : d.get_value('postgres', 'db'),
                 'host'     : d.get_value('postgres', 'host'),
                 'port'     : d.get_value('postgres', 'port', int)
     }

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -19,7 +19,7 @@ from ..conf import CONF
 from .exceptions import FromUser
 from .amqp import publish, get_connection
 
-LOG = logging.getLogger('db')
+LOG = logging.getLogger(__name__)
 
 class Status(Enum):
     Received = 'Received'
@@ -32,19 +32,19 @@ class Status(Enum):
 ##         DB connection            ##
 ######################################
 def fetch_args(d):
-    db_args = { 'user'     : d.get_or_else('postgres', 'user'),
-                'password' : d.get_or_else('postgres', 'password'),
-                'database' : d.get_or_else('postgres', 'dbname'),
-                'host'     : d.get_or_else('postgres', 'host'),
-                'port'     : d.getint_or_else('postgres', 'port')
+    db_args = { 'user'     : d.get_value('postgres', 'user'),
+                'password' : d.get_value('postgres', 'password'),
+                'database' : d.get_value('postgres', 'dbname'),
+                'host'     : d.get_value('postgres', 'host'),
+                'port'     : d.get_value('postgres', 'port', int)
     }
     LOG.info(f"Initializing a connection to: {db_args['host']}:{db_args['port']}/{db_args['database']}")
     return db_args
 
 async def _retry(run, on_failure=None, exception=psycopg2.OperationalError):
     '''Main retry loop'''
-    nb_try = CONF.getint_or_else('postgres', 'try', 1)
-    try_interval = CONF.getint_or_else('postgres', 'try_interval', 1)
+    nb_try = CONF.get_value('postgres', 'try', int, 1)
+    try_interval = CONF.get_value('postgres', 'try_interval', int, 1)
     LOG.debug(f"{nb_try} attempts (every {try_interval} seconds)")
     count = 0
     backoff = try_interval

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -32,19 +32,19 @@ class Status(Enum):
 ##         DB connection            ##
 ######################################
 def fetch_args(d):
-    db_args = { 'user'     : d.get('db','username'),
-                'password' : d.get('db','password'),
-                'database' : d.get('db','dbname'),
-                'host'     : d.get('db','host'),
-                'port'     : d.getint('db','port')
+    db_args = { 'user'     : d.get_or_else('postgres', 'user'),
+                'password' : d.get_or_else('postgres', 'password'),
+                'database' : d.get_or_else('postgres', 'dbname'),
+                'host'     : d.get_or_else('postgres', 'host'),
+                'port'     : d.getint_or_else('postgres', 'port')
     }
     LOG.info(f"Initializing a connection to: {db_args['host']}:{db_args['port']}/{db_args['database']}")
     return db_args
 
 async def _retry(run, on_failure=None, exception=psycopg2.OperationalError):
     '''Main retry loop'''
-    nb_try   = CONF.getint('db','try', fallback=1)
-    try_interval = CONF.getint('db','try_interval', fallback=1)
+    nb_try = CONF.getint_or_else('postgres', 'try', 1)
+    try_interval = CONF.getint_or_else('postgres', 'try_interval', 1)
     LOG.debug(f"{nb_try} attempts (every {try_interval} seconds)")
     count = 0
     backoff = try_interval
@@ -66,7 +66,7 @@ async def _retry(run, on_failure=None, exception=psycopg2.OperationalError):
         LOG.error(f"Database connection fail after {nb_try} attempts ...")
     else:
         LOG.error("Database connection attempts was set to 0 ...")
-        
+
     if on_failure:
         on_failure()
 
@@ -138,7 +138,7 @@ def insert_file(filename, user_id, stable_id):
                 return file_id
             else:
                 raise Exception('Database issue with insert_file')
- 
+
 
 def get_errors(from_user=False):
     query = 'SELECT * from errors WHERE from_user = true;' if from_user else 'SELECT * from errors;'

--- a/lega/utils/eureka.py
+++ b/lega/utils/eureka.py
@@ -10,7 +10,6 @@ import aiohttp
 import logging
 import json
 import uuid
-import sys
 from functools import wraps
 
 
@@ -22,7 +21,7 @@ eureka_status = {
     4: 'UNKNOWN',
 }
 
-LOG = logging.getLogger('eureka')
+LOG = logging.getLogger(__name__)
 
 
 async def _retry(run, on_failure=None):

--- a/lega/vault.py
+++ b/lega/vault.py
@@ -18,7 +18,7 @@ from .utils import db
 from .utils.amqp import consume
 
 
-LOG = logging.getLogger('vault')
+LOG = logging.getLogger(__name__)
 
 @db.catch_error
 def work(data):
@@ -29,7 +29,7 @@ def work(data):
     filepath      = Path(data['internal_data']['filepath'])
 
     # Create the target name from the file_id
-    vault_area = Path(CONF.get_or_else('vault', 'path'))
+    vault_area = Path(CONF.get_value('vault', 'path'))
     name = f"{file_id:0>20}" # filling with zeros, and 20 characters wide
     name_bits = [name[i:i+3] for i in range(0, len(name), 3)]
     target = vault_area.joinpath(*name_bits)

--- a/lega/vault.py
+++ b/lega/vault.py
@@ -29,7 +29,7 @@ def work(data):
     filepath      = Path(data['internal_data']['filepath'])
 
     # Create the target name from the file_id
-    vault_area = Path( CONF.get('vault','location') )
+    vault_area = Path(CONF.get_or_else('vault', 'path'))
     name = f"{file_id:0>20}" # filling with zeros, and 20 characters wide
     name_bits = [name[i:i+3] for i in range(0, len(name), 3)]
     target = vault_area.joinpath(*name_bits)

--- a/lega/verify.py
+++ b/lega/verify.py
@@ -20,7 +20,7 @@ from .conf import CONF
 from .utils import checksum, db, exceptions
 from .utils.amqp import consume
 
-LOG = logging.getLogger('verify')
+LOG = logging.getLogger(__name__)
 
 @db.catch_error
 def work(data):


### PR DESCRIPTION
As the title suggest adding support to read configuration values (values that currently exist in `defaults.ini`) from ENV variables. This should enable some features (e.g. setting in an YML file env variables so that these can be exposed to the container and read by LocalEGA; flexibility in the way one can work with configuring LocalEGA) for the way we deploy the application.
The way it works it looks first if that environment variable is set otherwise it will look in `defaults.ini` or in the `--conf` file provided, thus it does not take away from the current functionality.

Added new logging solution for lega with:
```
  lega:
    level: INFO
    handlers: [console]
    propagate: true
    qualname: lega
```

Fixed also one missing parameter for vault entrypoint `gosu lega ega-verify`

A list of environment variables as well as other specific configuration settings has been compiled here: https://github.com/NBISweden/LocalEGA/wiki/Configuration-Settings-%7C-Environment-Variables