### PR TITLE
New MQ queues and bindings for Quality Controllers

### DIFF
--- a/deployments/docker/images/mq/defs.json
+++ b/deployments/docker/images/mq/defs.json
@@ -5,11 +5,16 @@
  "parameters":[],
  "global_parameters":[{"name":"cluster_name","value":"rabbit@localhost"}],
  "policies":[],
- "queues":[{"name":"archived",   "vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
- 	   {"name":"staged",     "vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
-	   {"name":"files",      "vhost":"/","durable":true,"auto_delete":false,"arguments":{}}],
+ "queues":[{"name":"files","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
+	   {"name":"staged","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
+	   {"name":"qc","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
+	   {"name":"qc.errors","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
+	   {"name":"qc.done","vhost":"/","durable":true,"auto_delete":false,"arguments":{}}],
  "exchanges":[{"name":"lega","vhost":"/","type":"topic","durable":true,"auto_delete":false,"internal":false,"arguments":{}},
               {"name":"cega","vhost":"/","type":"topic","durable":true,"auto_delete":false,"internal":false,"arguments":{}}],
- "bindings":[{"source":"lega","vhost":"/","destination":"archived","destination_type":"queue","routing_key":"archived","arguments":{}},
-	     {"source":"lega","vhost":"/","destination":"staged","destination_type":"queue","routing_key":"staged","arguments":{}}]
+ "bindings":[{"source":"lega", "vhost":"/", "destination":"staged",    "destination_type":"queue", "routing_key":"staged",    "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"qc",        "destination_type":"queue", "routing_key":"completed", "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"qc.done",   "destination_type":"queue", "routing_key":"qc.done",   "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"qc.errors", "destination_type":"queue", "routing_key":"qc.errors", "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"cega",      "destination_type":"exchange", "routing_key":"qc.errors","arguments":{}}]
 }


### PR DESCRIPTION
I reuse the lega exchange with the following changes:

* Upon completion, the message is shovelled to the cega exchange (which sends it to CentralEGA too) and now also to the `qc` (internal) queue.
* When the quality control is finished, a message can be published to the `lega` exchange, with the routing key `qc.done`.
* In case of errors, send the message to the `lega` exchange with the routing key `qc.errors`. It will be sent an internal queue and also to Central EGA.