### PR TITLE
Messages

### DIFF
--- a/deployments/docker/bootstrap/lega.sh
+++ b/deployments/docker/bootstrap/lega.sh
@@ -243,11 +243,13 @@ services:
       - ./lega/conf.ini:/etc/ega/conf.ini:ro
       - inbox:/ega/inbox
       - ../../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
+      - ../images/inbox/entrypoint.sh:/usr/bin/ega-entrypoint.sh
       #- ~/_auth_ega:/root/_auth_ega
     restart: on-failure:3
     networks:
       - lega
       - cega
+    entrypoint: ["/bin/bash", "/usr/bin/ega-entrypoint.sh"]
 
   # Ingestion Workers
   ingest:

--- a/deployments/docker/bootstrap/lega.sh
+++ b/deployments/docker/bootstrap/lega.sh
@@ -41,7 +41,7 @@ EOF
 echomsg "\t* conf.ini"
 cat > ${PRIVATE}/lega/conf.ini <<EOF
 [DEFAULT]
-log = /etc/ega/logger.yml
+log = console
 
 [keyserver]
 port = 8443

--- a/deployments/docker/bootstrap/lega.sh
+++ b/deployments/docker/bootstrap/lega.sh
@@ -293,7 +293,7 @@ services:
       - ./lega/conf.ini:/etc/ega/conf.ini:ro
       - ./lega/logger.yml:/etc/ega/logger.yml:ro
       - inbox:/ega/inbox
-      #- ../../../lega:/root/.local/lib/python3.6/site-packages/lega
+      - ../../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
       #- ~/_auth_ega:/root/_auth_ega
     restart: on-failure:3
     networks:
@@ -316,7 +316,7 @@ services:
        - inbox:/ega/inbox
        - ./lega/conf.ini:/etc/ega/conf.ini:ro
        - ./lega/logger.yml:/etc/ega/logger.yml:ro
-       #- ../../../lega:/root/.local/lib/python3.6/site-packages/lega
+       - ../../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
        #- ~/_cryptor/legacryptor:/root/.local/lib/python3.6/site-packages/legacryptor
     restart: on-failure:3
     networks:
@@ -340,7 +340,7 @@ services:
        - ./lega/certs/ssl.key:/etc/ega/ssl.key:ro
        - ./lega/pgp/ega.sec:/etc/ega/pgp/ega.sec:ro
        - ./lega/pgp/ega2.sec:/etc/ega/pgp/ega2.sec:ro
-       #- ../../../lega:/root/.local/lib/python3.6/site-packages/lega
+       - ../../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
     restart: on-failure:3
     external_links:
       - cega-eureka:cega-eureka
@@ -368,7 +368,7 @@ services:
     volumes:
        - ./lega/conf.ini:/etc/ega/conf.ini:ro
        - ./lega/logger.yml:/etc/ega/logger.yml:ro
-       #- ../../../lega:/root/.local/lib/python3.6/site-packages/lega
+       - ../../../lega:/home/lega/.local/lib/python3.6/site-packages/lega
        #- ~/_cryptor/legacryptor:/root/.local/lib/python3.6/site-packages/legacryptor
     restart: on-failure:3
     networks:

--- a/deployments/docker/images/inbox/Dockerfile
+++ b/deployments/docker/images/inbox/Dockerfile
@@ -23,6 +23,6 @@ COPY banner /ega/banner
 COPY pam.ega /etc/pam.d/ega
 COPY sshd_config /etc/ega/sshd_config
 RUN cp /usr/sbin/sshd /usr/sbin/ega
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod 755 /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
+# COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+# RUN chmod 755 /usr/local/bin/entrypoint.sh
+# ENTRYPOINT ["entrypoint.sh"]

--- a/deployments/docker/images/inbox/entrypoint.sh
+++ b/deployments/docker/images/inbox/entrypoint.sh
@@ -14,7 +14,8 @@ EGA_UID=$(id -u lega)
 EGA_GID=$(id -g lega)
 
 # For the home directories
-mkdir -m 750 /lega
+mkdir -p /lega
+chmod 750 /lega
 
 cat > /etc/ega/auth.conf <<EOF
 enable_cega = yes

--- a/deployments/docker/images/mq/defs.json
+++ b/deployments/docker/images/mq/defs.json
@@ -6,15 +6,15 @@
  "global_parameters":[{"name":"cluster_name","value":"rabbit@localhost"}],
  "policies":[],
  "queues":[{"name":"files","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
-	   {"name":"staged","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
+	   {"name":"archived","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
 	   {"name":"qc","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
 	   {"name":"qc.errors","vhost":"/","durable":true,"auto_delete":false,"arguments":{}},
 	   {"name":"qc.done","vhost":"/","durable":true,"auto_delete":false,"arguments":{}}],
  "exchanges":[{"name":"lega","vhost":"/","type":"topic","durable":true,"auto_delete":false,"internal":false,"arguments":{}},
               {"name":"cega","vhost":"/","type":"topic","durable":true,"auto_delete":false,"internal":false,"arguments":{}}],
- "bindings":[{"source":"lega", "vhost":"/", "destination":"staged",    "destination_type":"queue", "routing_key":"staged",    "arguments":{}},
-	     {"source":"lega", "vhost":"/", "destination":"qc",        "destination_type":"queue", "routing_key":"qc",        "arguments":{}},
-	     {"source":"lega", "vhost":"/", "destination":"qc.done",   "destination_type":"queue", "routing_key":"qc.done",   "arguments":{}},
-	     {"source":"lega", "vhost":"/", "destination":"qc.errors", "destination_type":"queue", "routing_key":"qc.errors", "arguments":{}},
-	     {"source":"lega", "vhost":"/", "destination":"cega",      "destination_type":"exchange", "routing_key":"qc.errors","arguments":{}}]
+ "bindings":[{"source":"lega", "vhost":"/", "destination":"archived",  "destination_type":"queue", "routing_key":"archived",     "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"qc",        "destination_type":"queue", "routing_key":"qc",           "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"qc.done",   "destination_type":"queue", "routing_key":"qc.done",      "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"qc.errors", "destination_type":"queue", "routing_key":"qc.errors",    "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"cega",      "destination_type":"exchange", "routing_key":"qc.errors", "arguments":{}}]
 }

--- a/deployments/docker/images/mq/defs.json
+++ b/deployments/docker/images/mq/defs.json
@@ -13,7 +13,7 @@
  "exchanges":[{"name":"lega","vhost":"/","type":"topic","durable":true,"auto_delete":false,"internal":false,"arguments":{}},
               {"name":"cega","vhost":"/","type":"topic","durable":true,"auto_delete":false,"internal":false,"arguments":{}}],
  "bindings":[{"source":"lega", "vhost":"/", "destination":"staged",    "destination_type":"queue", "routing_key":"staged",    "arguments":{}},
-	     {"source":"lega", "vhost":"/", "destination":"qc",        "destination_type":"queue", "routing_key":"completed", "arguments":{}},
+	     {"source":"lega", "vhost":"/", "destination":"qc",        "destination_type":"queue", "routing_key":"qc",        "arguments":{}},
 	     {"source":"lega", "vhost":"/", "destination":"qc.done",   "destination_type":"queue", "routing_key":"qc.done",   "arguments":{}},
 	     {"source":"lega", "vhost":"/", "destination":"qc.errors", "destination_type":"queue", "routing_key":"qc.errors", "arguments":{}},
 	     {"source":"lega", "vhost":"/", "destination":"cega",      "destination_type":"exchange", "routing_key":"qc.errors","arguments":{}}]

--- a/deployments/docker/test/.gitignore
+++ b/deployments/docker/test/.gitignore
@@ -1,0 +1,5 @@
+*.bam
+*.c4ga
+*.c4ga.md5
+*.md5
+mq.env

--- a/deployments/docker/test/Makefile
+++ b/deployments/docker/test/Makefile
@@ -1,0 +1,54 @@
+.PHONY: upload submit user
+
+MAIN_REPO=~/_ega
+SSH_KEY_PUB=~/.ssh/lega.pub
+SSH_KEY_PRIV=~/.ssh/lega
+
+USER=ega-box-999
+FILE=HG00458.unmapped.ILLUMINA.bwa.CHS.low_coverage.20130415.bam
+
+##############################
+
+DOCKER_PATH=$(MAIN_REPO)/deployments/docker
+INSTANCE_PORT=$(shell awk -F= '/DOCKER_PORT_inbox/ {print $$2}' $(DOCKER_PATH)/bootstrap/settings.rc)
+PGP_PUB=$(DOCKER_PATH)/private/lega/pgp/ega.pub
+PGP_EMAIL=$(shell awk -F= '/PGP_EMAIL/ {print $$2}' $(DOCKER_PATH)/bootstrap/settings.rc)
+CEGA_USERS=$(DOCKER_PATH)/private/cega/users
+CEGA_MQ_CONNECTION=$(shell awk -F= '/^CEGA_CONNECTION/ {print $$2}' $(DOCKER_PATH)/private/lega/mq.env)
+
+##############################
+
+all: user upload submit
+
+# $(FILE):
+# 	@echo 'Hello' > $(FILE)
+
+$(FILE).c4ga: $(FILE)
+	lega-cryptor encrypt --pk $(PGP_PUB) -i $< -o $@
+
+#	lega-cryptor encrypt -r Sweden -i $< -o $@
+
+upload: $(FILE).c4ga
+	cd $(<D) && sftp -P $(INSTANCE_PORT) -i $(SSH_KEY_PRIV) $(USER)@localhost <<< $$"put $(<F)"
+
+$(FILE).c4ga.md5: $(FILE).c4ga
+	printf '%s' $(shell md5 $< | cut -d' ' -f4) > $@
+
+$(FILE).md5: $(FILE)
+	printf '%s' $(shell md5 $< | cut -d' ' -f4) > $@
+
+submit: $(FILE).c4ga $(FILE).c4ga.md5 $(FILE).md5
+	@echo publish.py --connection amqp://[redacted]@$(lastword $(subst @, ,$(CEGA_MQ_CONNECTION))) $(USER) dir/$(FILE).c4ga --enc ...
+	@python ~/_ega/extras/publish.py --connection $(subst cega-mq,localhost,$(CEGA_MQ_CONNECTION)) $(USER) $(FILE).c4ga --enc $(shell cat $(FILE).c4ga.md5) EGAF$(shell cat $(FILE).md5)
+
+user: $(CEGA_USERS)/lega/$(USER).yml
+
+$(CEGA_USERS)/lega/$(USER).yml: $(CEGA_USERS)/$(USER).yml
+	-cd $(CEGA_USERS)/lega && ln -s ../$(USER).yml .
+$(CEGA_USERS)/$(USER).yml:
+	@echo --- > $@
+	@echo "pubkey: $(shell cat $(SSH_KEY_PUB))" >> $@
+
+clean:
+	-unlink $(CEGA_USERS)/lega/$(USER).yml
+	rm -rf $(FILE).c4ga $(FILE).c4ga.md5 $(FILE).md5 $(CEGA_USERS)/$(USER).yml

--- a/deployments/docker/tests/pom.xml
+++ b/deployments/docker/tests/pom.xml
@@ -59,9 +59,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.uio-bmi</groupId>
+            <groupId>no.uio.ifi</groupId>
             <artifactId>crypt4gh</artifactId>
-            <version>master</version>
+            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -111,7 +111,7 @@
     <repositories>
         <repository>
             <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
+            <url>https://github.com/uio-bmi/crypt4gh/raw/maven</url>
         </repository>
     </repositories>
 

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/Context.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/Context.java
@@ -4,11 +4,9 @@ import lombok.Data;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
-import org.c02e.jpgpj.HashingAlgorithm;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 @Data

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
@@ -115,16 +115,16 @@ public class Utils {
                 "psql", "-U", readTraceProperty("DB_USER"), "-d", "lega", "-c", query);
     }
 
-    /**
-     * Removes the user from the local database.
-     *
-     * @param user     Username.
-     * @throws InterruptedException In case the query execution is interrupted.
-     */
-    public void removeUserFromCache(String user) throws InterruptedException {
-        executeWithinContainer(findContainer(getProperty("images.name.inbox"), getProperty("container.name.inbox")),
-                String.format("rm -rf %s/%s", getProperty("inbox.cache.path"), user).split(" "));
-    }
+    // /**
+    //  * Removes the user from the local database.
+    //  *
+    //  * @param user     Username.
+    //  * @throws InterruptedException In case the query execution is interrupted.
+    //  */
+    // public void removeUserFromCache(String user) throws InterruptedException {
+    //     executeWithinContainer(findContainer(getProperty("images.name.inbox"), getProperty("container.name.inbox")),
+    //             String.format("rm -rf %s/%s", getProperty("inbox.cache.path"), user).split(" "));
+    // }
 
 //    /**
 //     * Removes the user's inbox.

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/Utils.java
@@ -11,18 +11,14 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.c02e.jpgpj.HashingAlgorithm;
-import se.nbis.lega.cucumber.publisher.Checksum;
 import se.nbis.lega.cucumber.publisher.Message;
 
 import javax.ws.rs.core.MediaType;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -115,17 +111,6 @@ public class Utils {
                 "psql", "-U", readTraceProperty("DB_USER"), "-d", "lega", "-c", query);
     }
 
-    // /**
-    //  * Removes the user from the local database.
-    //  *
-    //  * @param user     Username.
-    //  * @throws InterruptedException In case the query execution is interrupted.
-    //  */
-    // public void removeUserFromCache(String user) throws InterruptedException {
-    //     executeWithinContainer(findContainer(getProperty("images.name.inbox"), getProperty("container.name.inbox")),
-    //             String.format("rm -rf %s/%s", getProperty("inbox.cache.path"), user).split(" "));
-    // }
-
 //    /**
 //     * Removes the user's inbox.
 //     *
@@ -142,7 +127,7 @@ public class Utils {
     /**
      * Removes the uploaded file from the inbox.
      *
-     * @param user     Username.
+     * @param user Username.
      * @throws InterruptedException In case the query execution is interrupted.
      */
     public void removeUploadedFileFromInbox(String user, String fileName) throws InterruptedException {

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/hooks/BeforeAfterHooks.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/hooks/BeforeAfterHooks.java
@@ -42,7 +42,7 @@ public class BeforeAfterHooks implements En {
         File cegaUsersFolder = new File(utils.getPrivateFolderPath() + "/cega/users/" + utils.getProperty("instance.name"));
         String user = context.getUser();
         Arrays.stream(cegaUsersFolder.listFiles((dir, name) -> name.startsWith(user))).forEach(File::delete);
-        utils.removeUserFromCache(user);
+//        utils.removeUserFromCache(user);
 //        utils.removeUserInbox(user);
     }
 

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/hooks/BeforeAfterHooks.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/hooks/BeforeAfterHooks.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.UUID;
 
 @Slf4j
 public class BeforeAfterHooks implements En {
@@ -31,18 +32,18 @@ public class BeforeAfterHooks implements En {
         FileUtils.writeStringToFile(rawFile, "hello", Charset.defaultCharset());
         context.setDataFolder(dataFolder);
         context.setRawFile(rawFile);
+        context.setUser(UUID.randomUUID().toString());
     }
 
     @SuppressWarnings({"ConstantConditions", "ResultOfMethodCallIgnored"})
     @After
-    public void tearDown() throws IOException, InterruptedException {
+    public void tearDown() throws IOException {
         Utils utils = context.getUtils();
 
         FileUtils.deleteDirectory(context.getDataFolder());
         File cegaUsersFolder = new File(utils.getPrivateFolderPath() + "/cega/users/" + utils.getProperty("instance.name"));
         String user = context.getUser();
         Arrays.stream(cegaUsersFolder.listFiles((dir, name) -> name.startsWith(user))).forEach(File::delete);
-//        utils.removeUserFromCache(user);
 //        utils.removeUserInbox(user);
     }
 

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Authentication.java
@@ -28,8 +28,6 @@ public class Authentication implements En {
     public Authentication(Context context) {
         Utils utils = context.getUtils();
 
-        Given("^My username is \"([^\"]*)\"$", context::setUser);
-
         Given("^I have an account at Central EGA$", () -> {
             String cegaUsersFolderPath = utils.getPrivateFolderPath() + "/cega/users/" + utils.getProperty("instance.name");
             String user = context.getUser();

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.exception.InternalServerErrorException;
 import cucumber.api.java8.En;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
-import org.c02e.jpgpj.HashingAlgorithm;
 import org.junit.Assert;
 import se.nbis.lega.cucumber.Context;
 import se.nbis.lega.cucumber.Utils;
@@ -156,8 +155,14 @@ public class Ingestion implements En {
                     context.getEncryptedFile().getName());
             // It may take a while for relatively big files to be ingested.
             // So we wait until ingestion status changes to something different from "In progress".
+            long maxTimeout = Long.parseLong(utils.getProperty("ingest.max-timeout"));
+            long timeout = 0;
             while ("In progress".equals(getIngestionStatus(context, utils))) {
                 Thread.sleep(1000);
+                timeout += 1000;
+                if (timeout > maxTimeout) {
+                    break;
+                }
             }
             // And we sleep one more second for entry to be updated in the database.
             Thread.sleep(1000);

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Uploading.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Uploading.java
@@ -4,6 +4,7 @@ import cucumber.api.java8.En;
 import lombok.extern.slf4j.Slf4j;
 import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import no.ifi.uio.crypt4gh.stream.Crypt4GHOutputStream;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import se.nbis.lega.cucumber.Context;
@@ -27,9 +28,10 @@ public class Uploading implements En {
             File rawFile = context.getRawFile();
             File encryptedFile = new File(rawFile.getAbsolutePath() + ".enc");
             try {
+                byte[] digest = DigestUtils.sha256(FileUtils.openInputStream(rawFile));
                 String key = FileUtils.readFileToString(new File(String.format("%s/%s/pgp/ega.pub", utils.getPrivateFolderPath(), utils.getProperty("instance.name"))), Charset.defaultCharset());
                 FileOutputStream fileOutputStream = new FileOutputStream(encryptedFile);
-                Crypt4GHOutputStream crypt4GHOutputStream = new Crypt4GHOutputStream(fileOutputStream, key);
+                Crypt4GHOutputStream crypt4GHOutputStream = new Crypt4GHOutputStream(fileOutputStream, key, digest);
                 FileUtils.copyFile(rawFile, crypt4GHOutputStream);
                 crypt4GHOutputStream.close();
                 context.setEncryptedFile(encryptedFile);

--- a/deployments/docker/tests/src/test/resources/config.properties
+++ b/deployments/docker/tests/src/test/resources/config.properties
@@ -2,7 +2,7 @@ private.folder.name = /private
 instance.name = lega
 trace.file.name = .trace
 inbox.folder.path = /lega
-inbox.cache.path = /ega/cache
+ingest.max-timeout = 10000
 
 images.name.db = postgres:latest
 images.name.inbox = nbisweden/ega-inbox

--- a/deployments/docker/tests/src/test/resources/cucumber/features/authentication.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/authentication.feature
@@ -1,9 +1,6 @@
 Feature: Authentication
   As a user I want to be able to authenticate against LocalEGA inbox
 
-  Background:
-    Given My username is "test"
-
   Scenario: A.0 User exists in Central EGA and uses correct private key for authentication for the correct instance
     Given I have an account at Central EGA
     And I have correct private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/checksums.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/checksums.feature
@@ -1,9 +1,6 @@
 Feature: Checksumming
   Deprecated, keeping it around just in case
 
-  Background:
-    Given My username is "test"
-
 #  Scenario: User ingests file encrypted with OpenPGP using a correct key, but raw checksum doesn't match with the supplied one
 #    Given I have an account at Central EGA
 #    And I have correct private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/checksums.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/checksums.feature
@@ -58,4 +58,4 @@ Feature: Checksumming
 #    And I have CEGA MQ username and password
 #    And I ingest file from the LocalEGA inbox without providing checksums
 #    When I retrieve ingestion information
-#    Then the ingestion status is "Archived"
+#    Then the ingestion status is "Completed"

--- a/deployments/docker/tests/src/test/resources/cucumber/features/checksums.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/checksums.feature
@@ -1,7 +1,7 @@
 Feature: Checksumming
   Deprecated, keeping it around just in case
 
-#  Scenario: User ingests file encrypted with OpenPGP using a correct key, but raw checksum doesn't match with the supplied one
+#  Scenario: User ingests file encrypted with Crypt4GH using a correct key, but raw checksum doesn't match with the supplied one
 #    Given I have an account at Central EGA
 #    And I have correct private key
 #    And I connect to the LocalEGA inbox via SFTP using private key
@@ -12,7 +12,7 @@ Feature: Checksumming
 #    When I retrieve ingestion information
 #    Then the ingestion status is "Error"
 
-#  Scenario: User ingests file encrypted with OpenPGP using a correct key, but encrypted checksum doesn't match with the supplied one
+#  Scenario: User ingests file encrypted with Crypt4GH using a correct key, but encrypted checksum doesn't match with the supplied one
 #    Given I have an account at Central EGA
 #    And I have correct private key
 #    And I connect to the LocalEGA inbox via SFTP using private key
@@ -23,7 +23,7 @@ Feature: Checksumming
 #    When I retrieve ingestion information
 #    Then the ingestion status is "Error"
 
-#  Scenario: User ingests file encrypted with OpenPGP using a correct key, but raw checksum isn't provided
+#  Scenario: User ingests file encrypted with Crypt4GH using a correct key, but raw checksum isn't provided
 #    Given I have an account at Central EGA
 #    And I have correct private key
 #    And I connect to the LocalEGA inbox via SFTP using private key
@@ -34,7 +34,7 @@ Feature: Checksumming
 #    When I retrieve ingestion information
 #    Then the ingestion status is "Error"
 
-#  Scenario: User ingests file encrypted with OpenPGP using a correct key, but encrypted checksum isn't provided
+#  Scenario: User ingests file encrypted with Crypt4GH using a correct key, but encrypted checksum isn't provided
 #    Given I have an account at Central EGA
 #    And I have correct private key
 #    And I connect to the LocalEGA inbox via SFTP using private key
@@ -45,7 +45,7 @@ Feature: Checksumming
 #    When I retrieve ingestion information
 #    Then the ingestion status is "Error"
 
-#  Scenario: User ingests file encrypted with OpenPGP using a correct key and providing checksums as companion files
+#  Scenario: User ingests file encrypted with Crypt4GH using a correct key and providing checksums as companion files
 #    Given I have an account at Central EGA
 #    And I have correct private key
 #    And I connect to the LocalEGA inbox via SFTP using private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -45,7 +45,7 @@ Feature: Ingestion
     And file is removed from the inbox
     And I ingest file from the LocalEGA inbox
     When I retrieve ingestion information
-    Then the ingestion status is "Received"
+    Then the ingestion status is "Error"
 
   Scenario: I.3 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the keyserver doesn't respond
     Given I have an account at Central EGA

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -1,9 +1,6 @@
 Feature: Ingestion
   As a user I want to be able to ingest files from the LocalEGA inbox
 
-  Background:
-    Given My username is "test"
-
   Scenario: I.0 User ingests file encrypted with OpenPGP using a correct key
     Given I have an account at Central EGA
     And I have correct private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -13,7 +13,7 @@ Feature: Ingestion
     And I have CEGA MQ username and password
     And I ingest file from the LocalEGA inbox
     When I retrieve ingestion information
-    Then the ingestion status is "Archived"
+    Then the ingestion status is "Completed"
 
   Scenario: I.1 User ingests file encrypted not with OpenPGP
     Given I have an account at Central EGA
@@ -64,7 +64,7 @@ Feature: Ingestion
     And I ingest file from the LocalEGA inbox
     And I turn on the keyserver
     When I retrieve ingestion information
-    Then the ingestion status is "Archived"
+    Then the ingestion status is "Completed"
 
   Scenario: I.4 User ingests file encrypted with OpenPGP using a correct key and checksums, but the vault listener is down
     Given I have an account at Central EGA

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -54,14 +54,11 @@ Feature: Ingestion
     And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
-    And I ingest file from the LocalEGA inbox
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
-    And I upload encrypted file to the LocalEGA inbox via SFTP
     And I turn off the keyserver
     And I ingest file from the LocalEGA inbox
     And I turn on the keyserver
     When I retrieve ingestion information
-    Then the ingestion status is "Completed"
+    Then the ingestion status is "Error"
 
   Scenario: I.4 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the vault listener is down
     Given I have an account at Central EGA

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -1,7 +1,7 @@
 Feature: Ingestion
   As a user I want to be able to ingest files from the LocalEGA inbox
 
-  Scenario: I.0 User ingests file encrypted with OpenPGP using a correct key
+  Scenario: I.0 User ingests file encrypted with Crypt4GH using a correct key
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
@@ -12,7 +12,7 @@ Feature: Ingestion
     When I retrieve ingestion information
     Then the ingestion status is "Completed"
 
-  Scenario: I.1 User ingests file encrypted not with OpenPGP
+  Scenario: I.1 User ingests file encrypted not with Crypt4GH
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
@@ -23,7 +23,7 @@ Feature: Ingestion
     When I retrieve ingestion information
     Then the ingestion status is "Error"
 
-#  Scenario: I.3 User ingests file encrypted with OpenPGP, but inbox is not created
+#  Scenario: I.3 User ingests file encrypted with Crypt4GH, but inbox is not created
 #    Given I have an account at Central EGA
 #    And I have correct private key
 #    And I connect to the LocalEGA inbox via SFTP using private key
@@ -35,7 +35,7 @@ Feature: Ingestion
 #    When I retrieve ingestion information
 #    Then the ingestion status is "Error"
 
-  Scenario: I.2 User ingests file encrypted with OpenPGP, but file was not found in the inbox
+  Scenario: I.2 User ingests file encrypted with Crypt4GH, but file was not found in the inbox
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
@@ -45,9 +45,9 @@ Feature: Ingestion
     And file is removed from the inbox
     And I ingest file from the LocalEGA inbox
     When I retrieve ingestion information
-    Then the ingestion status is "Error"
+    Then the ingestion status is "Received"
 
-  Scenario: I.3 User ingests file encrypted with OpenPGP using a correct key and checksums, but the keyserver doesn't respond
+  Scenario: I.3 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the keyserver doesn't respond
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
@@ -63,7 +63,7 @@ Feature: Ingestion
     When I retrieve ingestion information
     Then the ingestion status is "Completed"
 
-  Scenario: I.4 User ingests file encrypted with OpenPGP using a correct key and checksums, but the vault listener is down
+  Scenario: I.4 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the vault listener is down
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
@@ -76,7 +76,7 @@ Feature: Ingestion
     When I retrieve ingestion information
     Then the ingestion status is "NoEntry"
 
-  Scenario: I.5 User ingests file encrypted with OpenPGP using a correct key and checksums, but the database doesn't respond
+  Scenario: I.5 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the database doesn't respond
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
@@ -14,7 +14,7 @@ Feature: Robustness
     And I have CEGA MQ username and password
     And I ingest file from the LocalEGA inbox
     When I retrieve ingestion information
-    Then the ingestion status is "Archived"
+    Then the ingestion status is "Completed"
 #
 #  Scenario: R.2 User ingests a big file encrypted with OpenPGP using a correct key and providing checksums as companion files
 #    Given I have an account at Central EGA

--- a/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
@@ -1,9 +1,6 @@
 Feature: Robustness
   As a user I want the system to be robust and fault-tolerant
 
-  Background:
-    Given My username is "test"
-
   Scenario: R.0 User ingests file encrypted with OpenPGP using a correct key and providing checksums as companion files after full system restart
     Given I have an account at Central EGA
     And I have correct private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
@@ -1,7 +1,7 @@
 Feature: Robustness
   As a user I want the system to be robust and fault-tolerant
 
-  Scenario: R.0 User ingests file encrypted with OpenPGP using a correct key and providing checksums as companion files after full system restart
+  Scenario: R.0 User ingests file encrypted with Crypt4GH using a correct key and providing checksums as companion files after full system restart
     Given I have an account at Central EGA
     And I have correct private key
     And the system is restarted
@@ -13,7 +13,7 @@ Feature: Robustness
     When I retrieve ingestion information
     Then the ingestion status is "Completed"
 #
-#  Scenario: R.2 User ingests a big file encrypted with OpenPGP using a correct key and providing checksums as companion files
+#  Scenario: R.2 User ingests a big file encrypted with Crypt4GH using a correct key and providing checksums as companion files
 #    Given I have an account at Central EGA
 #    And I have correct private key
 #    And I connect to the LocalEGA inbox via SFTP using private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/uploading.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/uploading.feature
@@ -1,9 +1,6 @@
 Feature: Uploading
   As a user I want to be able to upload files to the LocalEGA inbox
 
-  Background:
-    Given My username is "test"
-
   Scenario: U.0 Upload files to the LocalEGA inbox
     Given I have an account at Central EGA
     And I have correct private key

--- a/extras/db.sql
+++ b/extras/db.sql
@@ -45,17 +45,21 @@ $insert_file$ LANGUAGE plpgsql;
 CREATE TABLE errors (
         id            SERIAL, PRIMARY KEY(id), UNIQUE (id),
 	file_id       INTEGER REFERENCES files (id) ON DELETE CASCADE,
+	hostname      TEXT,
+	error_type    TEXT NOT NULL,
 	msg           TEXT NOT NULL,
 	from_user     BOOLEAN DEFAULT FALSE,
 	occured_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
 );
 
-CREATE FUNCTION insert_error(file_id    errors.file_id%TYPE,
-                             msg        errors.msg%TYPE,
+CREATE FUNCTION insert_error(fid   errors.file_id%TYPE,
+                             h     errors.hostname%TYPE,
+                             etype errors.error_type%TYPE,
+                             msg   errors.msg%TYPE,
                              from_user  errors.from_user%TYPE)
     RETURNS void AS $set_error$
     BEGIN
-       INSERT INTO errors (file_id,msg,from_user) VALUES(file_id,msg,from_user);
+       INSERT INTO errors (file_id,hostname,error_type,msg,from_user) VALUES(fid,h,etype,msg,from_user);
        UPDATE files SET status = 'Error' WHERE id = file_id;
     END;
 $set_error$ LANGUAGE plpgsql;

--- a/extras/db.sql
+++ b/extras/db.sql
@@ -60,6 +60,6 @@ CREATE FUNCTION insert_error(fid   errors.file_id%TYPE,
     RETURNS void AS $set_error$
     BEGIN
        INSERT INTO errors (file_id,hostname,error_type,msg,from_user) VALUES(fid,h,etype,msg,from_user);
-       UPDATE files SET status = 'Error' WHERE id = file_id;
+       UPDATE files SET status = 'Error' WHERE id = fid;
     END;
 $set_error$ LANGUAGE plpgsql;

--- a/lega/conf/loggers/console.yaml
+++ b/lega/conf/loggers/console.yaml
@@ -15,25 +15,11 @@ loggers:
   aiopg:
     level: INFO
     handlers: [console]
-  aiohttp.access:
+  aiohttp:
     level: INFO
     handlers: [console]
-  aiohttp.client:
-    level: INFO
-    handlers: [console]
-  aiohttp.internal:
-    level: INFO
-    handlers: [console]
-  aiohttp.server:
-    level: INFO
-    handlers: [console]
-  aiohttp.web:
-    level: INFO
-    handlers: [console]
-  aiohttp.websocket:
-    level: INFO
-    handlers: [console]
-
+    propagate: true
+    qualname: aiohttp
 
 handlers:
   noHandler:

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -18,7 +18,7 @@ and optionally an integrity field, called ``unencrypted_integrity``, with:
 * ``algorithm`` - the associated hash algorithm
 
 Upon completion, a message is sent to the local exchange with the
-routing key :``staged``.
+routing key :``archived``.
 '''
 
 import sys
@@ -141,7 +141,7 @@ def main(args=None):
     do_work = partial(work, fs())
 
     # upstream link configured in local broker
-    consume(do_work, 'files', 'staged')
+    consume(do_work, 'files', 'archived')
 
 if __name__ == '__main__':
     main()

--- a/lega/keyserver.py
+++ b/lega/keyserver.py
@@ -62,7 +62,7 @@ class Cache:
     def check_ttl(self):
         """Check ttl for all keys."""
         keys = []
-        for key, (_, _, expire) in self.store.items():
+        for key, (_, _, _, _, expire) in self.store.items():
             if expire and time.time() < expire:
                 keys.append({"keyID": key, "ttl": self._time_delta(expire)})
             if expire is None:

--- a/lega/keyserver.py
+++ b/lega/keyserver.py
@@ -42,21 +42,21 @@ class Cache:
         ttl = self.ttl if not ttl else self._parse_date_time(ttl)
         assert key.is_protected and key.is_unlocked, "The PGPKey must be protected and unlocked"
         key.protect(self.key, pgpy.constants.SymmetricKeyAlgorithm.AES256, pgpy.constants.HashAlgorithm.SHA256)  # re-protect
-        self.store[keyid] = (bytes(key.pubkey), bytes(key), ttl)
+        self.store[keyid] = (bytes(key.pubkey), bytes(key), str(key.pubkey), str(key), ttl)
 
-    def get(self, keyid, key_type):
+    def get(self, keyid, key_type, key_format=None):
         """Retrieve value based on key."""
         data = self.store.get(keyid)
         if not data:
             return None
-        pubkey, privkey, expire = data
+        pubkey, privkey, pubkey_armored, privkey_armored, expire = data
         if expire and time.time() > expire:
             del self.store[keyid]
             return None
         if key_type == 'public':
-            return pubkey
+            return pubkey_armored if key_format == 'armored' else pubkey
         if key_type == 'private':
-            return privkey
+            return privkey_armored if key_format == 'armored' else privkey
         return None
 
     def check_ttl(self):
@@ -128,9 +128,10 @@ async def retrieve_active_key(request):
     LOG.debug(f'Requesting active ({key_type}) key')
     if key_type not in ('public', 'private'):
         return web.HTTPForbidden() # web.HTTPBadRequest()
+    key_format = 'armored' if request.content_type == 'text/plain' else None
     if _active is None:
         return web.HTTPNotFound()
-    k = _cache.get(_active, key_type)
+    k = _cache.get(_active, key_type, key_format=key_format)
     if k:
         return web.Response(body=k) # web.Response(text=k.hex())
     else:
@@ -145,8 +146,9 @@ async def retrieve_key(request):
     if key_type not in ('public', 'private'):
         return web.HTTPForbidden() # web.HTTPBadRequest()
     key_id = requested_id[-16:].upper()
+    key_format = 'armored' if request.content_type == 'text/plain' else None
     LOG.debug(f'Requested {key_type.upper()} key with ID {requested_id}')
-    k = _cache.get(key_id, key_type)
+    k = _cache.get(key_id, key_type, key_format=key_format)
     if k:
         return web.Response(body=k) # web.Response(text=value.hex())
     else:

--- a/lega/utils/amqp.py
+++ b/lega/utils/amqp.py
@@ -70,7 +70,7 @@ def publish(message, channel, exchange, routing, correlation_id=None):
                                                              delivery_mode=2))
 
 
-def consume(work, from_queue, to_routing):
+def consume(work, connection, from_queue, to_routing):
     '''Blocking function, registering callback `work` to be called.
 
     from_broker must be a pair (from_connection: pika:Connection, from_queue: str)
@@ -85,7 +85,6 @@ def consume(work, from_queue, to_routing):
     '''
 
     assert( from_queue and to_routing )
-    connection = get_connection('broker')
 
     LOG.debug(f'Consuming message from {from_queue}')
 

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -231,13 +231,13 @@ def catch_error(func):
 
             try:
                 data = args[-1] # data is the last argument
-                internal_data = data.pop('internal_data', None) # delete if exists
-                file_id = internal_data['file_id'] # raise KeyError if missing
+                org_msg = data.get('org_msg', None)
+                file_id = data['file_id'] # raise KeyError if missing
                 set_error(file_id, e, from_user)
                 if from_user: # Send to CEGA
-                    data['status'] = { 'state': 'ERROR', 'message': str(e) } # str = Informal
-                    LOG.info(f'Sending user error to local broker: {data}')
-                    publish(data, get_connection('broker').channel(), 'cega', 'files.error')
+                    org_msg['status'] = { 'state': 'ERROR', 'message': str(e) } # str = Informal
+                    LOG.info(f'Sending user error to local broker: {org_msg}')
+                    publish(org_msg, get_connection('broker').channel(), 'cega', 'files.error')
             except Exception as e2:
                 LOG.error(f'While treating {e}, we caught {e2!r}')
                 print(repr(e), 'caused', repr(e2), file=sys.stderr)

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -183,7 +183,7 @@ def set_info(file_id, vault_path, vault_filesize, header):
                          'file_id': file_id,
                          'vault_path': vault_path,
                          'vault_filesize': vault_filesize,
-                         'header': header.hex(),
+                         'header': header,
                         })
 
 ######################################

--- a/lega/utils/exceptions.py
+++ b/lega/utils/exceptions.py
@@ -5,7 +5,10 @@ Exceptions
 
 import legacryptor
 
-# Errors for the users
+#############################################################################
+# User Errors
+#############################################################################
+
 class FromUser(Exception):
     def __str__(self): # Informal description
         return 'Incorrect user input'
@@ -44,38 +47,38 @@ class Checksum(FromUser):
     def __repr__(self):
         return 'Invalid {} checksum for the {} file: {}'.format(self.algo, 'original' if self.decrypted else 'encrypted', self.file)
 
+#############################################################################
+# PGP Key Error. Not all are from the user
+#############################################################################
 
-class WrongPGPKey(FromUser):
+class PGPKeyError(Exception):
     def __init__(self, msg):
         self.msg = msg
     def __str__(self):
-        return f'Using the wrong PGP key'
+        return 'PGP Key error'
     def __repr__(self):
-        return f'Using the wrong PGP key: {self.msg}'
+        return f'PGP Key error: {self.msg}'
 
+class KeyserverError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+    def __str__(self):
+        return 'Keyserver error'
+    def __repr__(self):
+        return f'Keyserver error: {self.msg}'
+
+#############################################################################
 # Any other exception is caught by us
-class MessageError(Exception):
-    def __str__(self):
-        return f'Error decoding the message from the queue'
-
-class VaultDecryption(Exception):
-    def __init__(self, filename):
-        self.filename = filename
-    def __str__(self):
-        return f'Decrypting archived file failed'
-    def __repr__(self):
-        return f'Decrypting {self.filename} from the vault failed'
+#############################################################################
 
 class AlreadyProcessed(Warning):
-    def __init__(self, filename, enc_checksum_hash, enc_checksum_algorithm, submission_id):
-        #self.file_id = file_id
+    def __init__(self, user, filename, enc_checksum_hash, enc_checksum_algorithm):
+        self.user = user
         self.filename = filename
         self.enc_checksum_hash = enc_checksum_hash
         self.enc_checksum_algorithm = enc_checksum_algorithm
-        self.submission_id = submission_id
     def __repr__(self):
         return (f'Warning: File already processed\n'
-                #f'\t* id: {self.file_id}\n'
+                f'\t* user: {self.user}\n'
                 f'\t* name: {self.filename}\n'
-                f'\t* submission id: {submission_id})\n'
                 f'\t* Encrypted checksum: {enc_checksum_hash} (algorithm: {enc_checksum_algorithm}')

--- a/lega/utils/exceptions.py
+++ b/lega/utils/exceptions.py
@@ -42,6 +42,14 @@ class Checksum(FromUser):
     def __repr__(self):
         return 'Invalid {} checksum for the {} file: {}'.format(self.algo, 'original' if self.decrypted else 'encrypted', self.file)
 
+class WrongPGPKey(FromUser):
+    def __init__(self, msg):
+        self.msg = msg
+    def __str__(self):
+        return f'Using the wrong PGP key'
+    def __repr__(self):
+        return f'Using the wrong PGP key: {self.msg}'
+
 # Any other exception is caught by us
 class MessageError(Exception):
     def __str__(self):

--- a/lega/utils/exceptions.py
+++ b/lega/utils/exceptions.py
@@ -3,6 +3,8 @@
 Exceptions
 '''
 
+import legacryptor
+
 # Errors for the users
 class FromUser(Exception):
     def __str__(self): # Informal description
@@ -41,6 +43,14 @@ class Checksum(FromUser):
         return 'Invalid {} checksum for the {} file'.format(self.algo, 'original' if self.decrypted else 'encrypted')
     def __repr__(self):
         return 'Invalid {} checksum for the {} file: {}'.format(self.algo, 'original' if self.decrypted else 'encrypted', self.file)
+
+
+class InvalidFormatError(FromUser, legacryptor.exceptions.InvalidFormatError):
+    pass
+class VersionError(FromUser, legacryptor.exceptions.VersionError):
+    pass
+class MDCError(FromUser, legacryptor.exceptions.MDCError):
+    pass
 
 class WrongPGPKey(FromUser):
     def __init__(self, msg):

--- a/lega/utils/exceptions.py
+++ b/lega/utils/exceptions.py
@@ -45,13 +45,6 @@ class Checksum(FromUser):
         return 'Invalid {} checksum for the {} file: {}'.format(self.algo, 'original' if self.decrypted else 'encrypted', self.file)
 
 
-class InvalidFormatError(FromUser, legacryptor.exceptions.InvalidFormatError):
-    pass
-class VersionError(FromUser, legacryptor.exceptions.VersionError):
-    pass
-class MDCError(FromUser, legacryptor.exceptions.MDCError):
-    pass
-
 class WrongPGPKey(FromUser):
     def __init__(self, msg):
         self.msg = msg

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -7,6 +7,7 @@ import shutil
 from pathlib import Path
 
 from ..conf import CONF
+import io
 
 LOG = logging.getLogger(__name__)
 
@@ -183,7 +184,6 @@ class S3Storage():
     def __init__(self):
         import boto3
         import socket
-        import io
 
         endpoint = CONF.get_value('vault', 'url')
         region = CONF.get_value('vault', 'region')

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -7,9 +7,6 @@ import shutil
 from pathlib import Path
 
 from ..conf import CONF
-import boto3
-import socket
-import io
 
 LOG = logging.getLogger(__name__)
 
@@ -184,6 +181,10 @@ class S3FileReader(object):
 
 class S3Storage():
     def __init__(self):
+        import boto3
+        import socket
+        import io
+
         endpoint = CONF.get_value('vault', 'url')
         region = CONF.get_value('vault', 'region')
         bucket = CONF.get_value('vault', 'bucket', default='lega')

--- a/lega/utils/storage.py
+++ b/lega/utils/storage.py
@@ -7,8 +7,12 @@ import shutil
 from pathlib import Path
 
 from ..conf import CONF
+import boto3
+import socket
+import io
 
 LOG = logging.getLogger(__name__)
+
 
 class FileStorage():
     def __init__(self):
@@ -180,10 +184,6 @@ class S3FileReader(object):
 
 class S3Storage():
     def __init__(self):
-        import boto3
-        import socket
-        import io
-
         endpoint = CONF.get_value('vault', 'url')
         region = CONF.get_value('vault', 'region')
         bucket = CONF.get_value('vault', 'bucket', default='lega')

--- a/lega/verify.py
+++ b/lega/verify.py
@@ -50,9 +50,13 @@ def get_records(header):
             return header_to_records(privkey, header, os.environ['LEGA_PASSWORD'])
     except HTTPError as e:
         LOG.error(e)
+        msg = str(e)
         if e.code == 404: # If key not found, then probably wrong key.
-            raise exceptions.WrongPGPKey(str(e))
-        # TODO: adjust properly so that we catch User errors from System errors.
+            raise exceptions.PGPKeyError(msg)
+        # Otherwise
+        raise exceptions.KeyserverError(msg)
+    except Exception as e:
+        raise exceptions.KeyserverError(str(e))
 
 @db.catch_error
 @db.crypt4gh_to_user_errors

--- a/lega/verify.py
+++ b/lega/verify.py
@@ -3,7 +3,7 @@
 
 '''Verifying the vault files
 
-This module reads a message from the ``staged`` queue, decrypts the
+This module reads a message from the ``archived`` queue, decrypts the
 files and recalculates its checksum.
 
 It the checksum matches the corresponding information in the file,
@@ -100,7 +100,7 @@ def main(args=None):
     chunk_size = CONF.get_value('vault', 'chunk_size', conv=int, default=1<<22) # 4 MB
     do_work = partial(work, chunk_size, store())
 
-    consume(do_work, 'staged', 'completed')
+    consume(do_work, 'archived', 'completed')
 
 if __name__ == '__main__':
     main()

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest import mock
+from lega.utils.amqp import get_connection, publish, consume
+
+
+class BrokerTest(unittest.TestCase):
+    """MQ Broker
+
+    Test broker connections."""
+
+    @mock.patch('lega.utils.amqp.CONF')
+    @mock.patch('lega.utils.amqp.pika')
+    def test_connection_blocking(self, mock_pika, mock_conf):
+        """Test if the pika BlockingConnection is called."""
+        sections = {'broker': {'hearbeat': 0, 'ssl': True}, 'other': {}}
+        mock_conf.sections = mock.Mock(return_value=sections.keys())
+
+        def values(domain, value, conv=str, default=None):
+            if value == 'heartbeat_interval':
+                return 1
+            elif value == 'ssl':
+                return True
+            else:
+                pass
+        mock_conf.get_value = mock.MagicMock(side_effect=values)
+        get_connection('broker')
+        mock_pika.BlockingConnection.assert_called()
+
+    @mock.patch('lega.utils.amqp.CONF')
+    @mock.patch('lega.utils.amqp.pika')
+    def test_connection_select(self, mock_pika, mock_conf):
+        """Test if the pika SelectConnection is called with paramters."""
+        sections = {'broker': {'hearbeat': 0, 'ssl': True}, 'other': {}}
+        mock_conf.sections = mock.Mock(return_value=sections.keys())
+        get_connection('broker', False)
+        mock_pika.SelectConnection.assert_called()
+
+    @mock.patch('lega.utils.amqp.get_connection')
+    def test_publish(self, mock_channel):
+        """Test if publish actually calls the publish to channel."""
+        mock_channel = mock.MagicMock(name='basic_publish')
+        mock_channel.basic_publish.return_value = mock.Mock()
+        publish('message', mock_channel, 'exchange', 'routing')
+        mock_channel.basic_publish.assert_called()
+
+    @mock.patch('lega.utils.amqp.publish')
+    def test_consume(self, mock_publish):
+        """Testing consume, should look into a queue."""
+        work = mock.Mock()
+        work.return_value = mock.MagicMock()
+        connection = mock.Mock()
+        connection.channel.return_value = mock.MagicMock()
+        consume(work, connection, 'queue', 'routing')
+        connection.channel.assert_called()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,8 @@
 import unittest
-from lega.utils.db import insert_file, get_errors, set_error, get_info, set_info, set_status, Status
+from lega.utils.db import insert_file, get_errors, set_error, get_info, set_info
+from lega.utils.db import set_status, Status, fetch_args, create_pool, connect
 from unittest import mock
+import asyncio
 
 
 class DBTest(unittest.TestCase):
@@ -10,7 +12,16 @@ class DBTest(unittest.TestCase):
 
     def setUp(self):
         """Initialise fixtures."""
+        self._loop = asyncio.get_event_loop()
         self._query_result = [("example", "result"), ("more", "results")]
+
+    @mock.patch('lega.utils.db.fetch_args')
+    @mock.patch('lega.utils.db.psycopg2')
+    def test_connect(self, mock_db_connect, mock_args):
+        """Test that connection is returning a connection."""
+        connect()
+        mock_args.assert_called()
+        mock_db_connect.connect.assert_called()
 
     @mock.patch('lega.utils.db.connect')
     def test_insert(self, mock_connect):
@@ -18,6 +29,13 @@ class DBTest(unittest.TestCase):
         mock_connect().__enter__().cursor().__enter__().fetchone.return_value = self._query_result
         result = insert_file('filename', 'user_id', 'stable_id')
         assert result == ("example", "result")
+
+    @mock.patch('lega.utils.db.connect')
+    def test_insert_fail(self, mock_connect):
+        """DB insert."""
+        mock_connect().__enter__().cursor().__enter__().fetchone.return_value = [()]
+        with self.assertRaises(Exception):
+            insert_file('filename', 'user_id', 'stable_id')
 
     @mock.patch('lega.utils.db.connect')
     def test_get_errors(self, mock_connect):
@@ -39,7 +57,7 @@ class DBTest(unittest.TestCase):
     @mock.patch('lega.utils.db.connect')
     def test_set_error(self, mock_connect):
         """DB set error."""
-        error = mock.MagicMock()
+        error = mock.Mock()
         error.__cause__ = mock.MagicMock(name='__cause__')
         error.__cause__.return_value = 'something'
         set_error('file_id', error)
@@ -58,3 +76,21 @@ class DBTest(unittest.TestCase):
         # Values are not important in this call
         set_status('file_id', Status.In_Progress)
         mock_connect().__enter__().cursor().__enter__().execute.assert_called()
+
+    @mock.patch('lega.utils.db.fetch_args')
+    @mock.patch('lega.utils.db.aiopg.create_pool')
+    def test_create_pool(self, mock_aiopg, mock_args):
+        """Create pool should call aipg and fetch args."""
+        f = asyncio.Future()
+        f.set_result('whatever result you want')
+        mock_aiopg.return_value = f
+        self._loop.run_until_complete(create_pool(self._loop))
+        mock_args.assert_called()
+        mock_aiopg.assert_called()
+
+    def test_fetch_args(self):
+        """Test fetching arguments."""
+        data_object = mock.MagicMock(name='get_value')
+        data_object.get_value.return_value = 'value'
+        result = fetch_args(data_object)
+        assert {'user': 'value', 'password': 'value', 'database': 'value', 'host': 'value', 'port': 'value'} == result

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -39,7 +39,10 @@ class DBTest(unittest.TestCase):
     @mock.patch('lega.utils.db.connect')
     def test_set_error(self, mock_connect):
         """DB set error."""
-        set_error('file_id', 'error')
+        error = mock.MagicMock()
+        error.__cause__ = mock.MagicMock(name='__cause__')
+        error.__cause__.return_value = 'something'
+        set_error('file_id', error)
         mock_connect().__enter__().cursor().__enter__().execute.assert_called()
 
     @mock.patch('lega.utils.db.connect')

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -157,6 +157,12 @@ class TestLegaFS(unittest.TestCase):
         self._fs.truncate('test.md5', 1)
         self.assertEqual({'test.md5'}, self._fs.pending)
 
+    def test_destroy(self):
+        """Test LegaFS destroy, should close connection to broker."""
+        self._fs.connection = mock.Mock()
+        self._fs.destroy('/random/path')
+        self._fs.connection.close.assert_called()
+
     @mock.patch('lega.inbox.publish')
     @mock.patch('lega.inbox.get_connection')
     @mock.patch('os.close')
@@ -169,7 +175,7 @@ class TestLegaFS(unittest.TestCase):
     @mock.patch('lega.inbox.publish')
     @mock.patch('lega.inbox.get_connection')
     def test_send_message(self, mock_broker, mock_publish):
-        """"Sending message should try to publish info to broker."""
+        """Sending message should try to publish info to broker."""
         self._fs.send_message('test.smth')
         self._fs.send_message('test.md5')
         mock_publish.assert_called()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2,6 +2,7 @@ import unittest
 from lega.ingest import main, run_checksum, work
 from unittest import mock
 from testfixtures import tempdir
+from lega.utils.exceptions import Checksum
 
 
 class testIngest(unittest.TestCase):
@@ -17,6 +18,23 @@ class testIngest(unittest.TestCase):
         run_checksum(data, 'encrypted_integrity', '/filename')
         mock.get_from_companion.assert_called()
         mock.is_valid.assert_called()
+
+    @mock.patch('lega.ingest.checksum')
+    def test_run_checksum_no_alg(self, mock):
+        """Testing running checksum, if there is already an algorithm key."""
+        mock.get_from_companion.return_value = '1', 'md5'
+        data = {'encrypted_integrity': {'checksum': '1', 'algorithm': None}}
+        result = run_checksum(data, 'encrypted_integrity', '/filename')
+        self.assertEqual(None, result)
+
+    @mock.patch('lega.ingest.checksum')
+    def test_run_checksum_not_valid(self, mock):
+        """Testing running checksum, if there is already an algorithm key."""
+        mock.get_from_companion.return_value = '1', 'md5'
+        mock.is_valid.return_value = False
+        data = {'encrypted_integrity': {'checksum': '1'}}
+        with self.assertRaises(Checksum):
+            run_checksum(data, 'encrypted_integrity', '/filename')
 
     @mock.patch('lega.ingest.get_connection')
     @mock.patch('lega.ingest.consume')

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,6 +1,7 @@
 import unittest
-from lega.ingest import main, run_checksum
+from lega.ingest import main, run_checksum, work
 from unittest import mock
+from testfixtures import tempdir
 
 
 class testIngest(unittest.TestCase):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -17,8 +17,9 @@ class testIngest(unittest.TestCase):
         mock.get_from_companion.assert_called()
         mock.is_valid.assert_called()
 
+    @mock.patch('lega.ingest.get_connection')
     @mock.patch('lega.ingest.consume')
-    def test_main(self, mock_consume):
+    def test_main(self, mock_consume, mock_connection):
         """Test main verify, by mocking cosume call."""
         mock_consume.return_value = mock.MagicMock()
         main()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,7 +3,7 @@ from lega.utils.storage import FileStorage, S3FileReader, S3Storage
 from test.support import EnvironmentVarGuard
 from testfixtures import TempDirectory
 import os
-import io
+from io import UnsupportedOperation
 from unittest import mock
 
 
@@ -51,15 +51,6 @@ class TestS3Storage(unittest.TestCase):
         self.env.unset('S3_ACCESS_KEY')
         self.env.unset('S3_SECRET_KEY')
 
-    @mock.patch('lega.utils.storage.boto3')
-    def test_location(self, boto3):
-        """Test S3 file location."""
-        _store = S3Storage()
-        result = _store.location('/test/path')
-        boto3.client.assert_called()
-        self.assertEqual('/test/path', result)
-        del _store
-
 
 class TestS3FileReader(unittest.TestCase):
     """S3FileReader
@@ -104,7 +95,7 @@ class TestS3FileReader(unittest.TestCase):
 
     def test_detach(self):
         """Detach should raise UnsupportedOperation."""
-        with self.assertRaises(io.UnsupportedOperation):
+        with self.assertRaises(UnsupportedOperation):
             self._reader.detach()
 
     def test_close(self):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,14 +1,15 @@
 import unittest
-from lega.utils.storage import FileStorage
+from lega.utils.storage import FileStorage, S3FileReader, S3Storage
 from test.support import EnvironmentVarGuard
 from testfixtures import TempDirectory
 import os
+from unittest import mock
 
 
 class TestFileStorage(unittest.TestCase):
     """FileStorage
 
-    Testing storge on disk."""
+    Testing storage on disk."""
 
     def setUp(self):
         """Initialise fixtures."""
@@ -27,3 +28,34 @@ class TestFileStorage(unittest.TestCase):
         """Test file location."""
         result = self._store.location('12')
         self.assertEqual(os.path.join(self.outputdir, '000/000/000/000/000/000/12'), result)
+
+
+class TestS3Storage(unittest.TestCase):
+    """S3Storage
+
+    Testing storage on S3 solution."""
+
+    def setUp(self):
+        """Initialise fixtures."""
+        self.env = EnvironmentVarGuard()
+        self.env.set('VAULT_URL', 'http://localhost:5000')
+        self.env.set('VAULT_REGION', 'lega')
+        self.env.set('S3_ACCESS_KEY', 'test')
+        self.env.set('S3_SECRET_KEY', 'test')
+
+    def tearDown(self):
+        """Remove setup variables."""
+        self.env.unset('VAULT_URL')
+        self.env.unset('VAULT_REGION')
+        self.env.unset('S3_ACCESS_KEY')
+        self.env.unset('S3_SECRET_KEY')
+
+
+class TestS3FileReader(unittest.TestCase):
+    """S3FileReader
+
+    Testing S3FileReader."""
+
+    def setUp(self):
+        """Initialise fixtures."""
+        self._reader = S3FileReader()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -54,8 +54,9 @@ class testVerify(unittest.TestCase):
             mocked.assert_called()
         filedir.cleanup()
 
+    @mock.patch('lega.verify.get_connection')
     @mock.patch('lega.verify.consume')
-    def test_main(self, mock_consume):
+    def test_main(self, mock_consume, mock_connection):
         """Test main verify, by mocking cosume call."""
         mock_consume.return_value = mock.MagicMock()
         main()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -5,6 +5,8 @@ from test.support import EnvironmentVarGuard
 from testfixtures import tempdir
 from . import pgp_data
 import io
+from urllib.error import HTTPError
+from lega.utils.exceptions import WrongPGPKey
 
 
 class PatchContextManager:
@@ -54,6 +56,32 @@ class testVerify(unittest.TestCase):
             mocked.assert_called()
         filedir.cleanup()
 
+    @tempdir()
+    @mock.patch('lega.verify.header_to_records')
+    @mock.patch('lega.verify.get_key_id')
+    def test_get_records_no_verify(self, mock_key, mock_records, filedir):
+        """Should call the url in order to provide the records even without a verify turned off."""
+        self.env.set('QUALITY_CONTROL_VERIFY_CERTIFICATE', 'False')
+        infile = filedir.write('infile.in', bytearray.fromhex(pgp_data.ENC_FILE))
+        returned_data = io.BytesIO(pgp_data.PGP_PRIVKEY.encode())
+        with PatchContextManager('lega.verify.urlopen', returned_data) as mocked:
+            get_records(open(infile, 'rb'))
+            mocked.assert_called()
+        filedir.cleanup()
+
+    @tempdir()
+    @mock.patch('lega.verify.header_to_records')
+    @mock.patch('lega.verify.get_key_id')
+    def test_get_records_error(self, mock_key, mock_records, filedir):
+        """The PGP key was not found, should raise WrongPGPKey error."""
+        self.env.set('QUALITY_CONTROL_VERIFY_CERTIFICATE', 'False')
+        infile = filedir.write('infile.in', bytearray.fromhex(pgp_data.ENC_FILE))
+        with mock.patch('lega.verify.urlopen') as urlopen_mock:
+            urlopen_mock.side_effect = HTTPError('url', 404, 'msg', None, None)
+            with self.assertRaises(WrongPGPKey):
+                get_records(open(infile, 'rb'))
+        filedir.cleanup()
+
     @mock.patch('lega.verify.get_connection')
     @mock.patch('lega.verify.consume')
     def test_main(self, mock_consume, mock_connection):
@@ -61,3 +89,25 @@ class testVerify(unittest.TestCase):
         mock_consume.return_value = mock.MagicMock()
         main()
         mock_consume.assert_called()
+
+    @tempdir()
+    @mock.patch('lega.verify.db')
+    @mock.patch('lega.verify.body_decrypt')
+    @mock.patch('lega.verify.publish')
+    @mock.patch('lega.verify.get_records')
+    def test_work(self, mock_records, mock_publish, mock_decrypt, mock_db, filedir):
+        """Test worker."""
+        # Mocking a lot of stuff, ast it is previously tested
+        mock_publish.return_value = mock.MagicMock()
+        mock_db.status.return_value = mock.Mock()
+        mock_records.return_value = ['data']
+        mock_decrypt.return_value = mock.Mock()
+        store = mock.MagicMock()
+        store.open.return_value = mock.MagicMock()
+        mock_broker = mock.MagicMock(name='channel')
+        mock_broker.channel.return_value = mock.Mock()
+        infile = filedir.write('infile.in', 'text'.encode("utf-8"))
+        data = {'header': pgp_data.ENC_FILE, 'stable_id': '1', 'vault_path': infile, 'file_id': '123', 'org_msg': {}}
+        result = work('10', store, mock_broker, data)
+        self.assertTrue({'status': {'state': 'COMPLETED', 'details': '1'}}, result)
+        filedir.cleanup()


### PR DESCRIPTION
Internal messages are now custom, and we keep the original message from CentralEGA into a 'org_msg' field.

When it is time to communicate to CentralEGA, we send the original message back with a status 'processing', 'completed' or 'error'.

In all other cases, we use the message internally and we, for example, avoid reading the database, since the data are already in the message. Useful for the QC step, for example.