### PR TITLE
Full header (not encrypted part only)

### DIFF
--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -117,14 +117,14 @@ def work(fs, channel, data):
     LOG.debug(f'Opening {inbox_filepath}')
     with open(inbox_filepath, 'rb') as infile:
         LOG.debug(f'Reading header | file_id: {file_id}')
-        header = get_header(infile)
+        beginning, header = get_header(infile)
 
         target = fs.location(file_id)
         LOG.info(f'[{fs.__class__.__name__}] Moving the rest of {filepath} to {target}')
         target_size = fs.copy(infile, target) # It will copy the rest only
 
         LOG.info(f'Vault copying completed. Updating database')
-        header_hex = header.hex()
+        header_hex = (beginning+header).hex()
         db.set_info(file_id, target, target_size, header_hex) # header bytes will be .hex()
         data['header'] = header_hex
         data['vault_path'] = target

--- a/lega/verify.py
+++ b/lega/verify.py
@@ -66,7 +66,7 @@ def work(chunk_size, mover, channel, data):
     LOG.info('Verification | message: %s', data)
 
     file_id = data['file_id']
-    header = bytes.fromhex(data['header']) # in hex -> bytes
+    header = bytes.fromhex(data['header'])[16:] # in hex -> bytes, and take away 16 bytes
     vault_path = data['vault_path']
     stable_id = data['stable_id']
 


### PR DESCRIPTION
A message in the QC queue now looks like: 

```
{
    "user": "ega-box-999",
    "filepath": "HG00458.unmapped.ILLUMINA.bwa.CHS.low_coverage.20130415.bam.c4ga",
    "stable_id": "EGAF108702b6e841bb8a8c17a5a262130c41",
    "encrypted_integrity": {
        "checksum": "814a2110d55a47365c10ad43e63eba83",
        "algorithm": "md5"
    },
    "file_id": 1,
    "user_id": "ega-box-999",
    "org_msg": {
        "user": "ega-box-999",
        "filepath": "HG00458.unmapped.ILLUMINA.bwa.CHS.low_coverage.20130415.bam.c4ga",
        "stable_id": "EGAF108702b6e841bb8a8c17a5a262130c41",
        "encrypted_integrity": {
            "checksum": "814a2110d55a47365c10ad43e63eba83",
            "algorithm": "md5"
        }
    },
    "header": "6372797074346768010000009d020000c1c14c039fd5b428f4a90376010ffc0a437351ae9cc3dfba5ab0ef69502880e877115e9fe4f055d8a6e0ebc1e03b1761dff6a9635d6bea1d39d68dfe3ce6240fa8617be5cdd46c864be258238eb7b346a4e3d2456cfe4193007614c16be10dc04cd2bff5f773d53fa90dd9f8c1a4fa0d74f4ac7e04191dccf1e19eee6fd334d1f6ce2f4dc7885a92b52972c723b518be8db3df94481e286e49cbd02b89889d0bfea817a99a74eacd76706a509497c374b3437571e6a852007b76ce406ead8e42bcadeff5f854c1dd0a9efdd10dfb4046a4be26d901a4289f81c96daeaf2e2637e4c1c64bb2e1f1306784ee7027164735b6ce20c886b06f4c68e447b33530c1c24f1be08ca47b94feaa43345f2322df56a6d5ef9a075181236745f088c0d764fd487f3665a365f7e3c49f59ef03d5fb12c4f2509fbace686fa2379b0f85409b95cd05ecbc0fd5566453ca6054a2ad3beb28a252b4423f24381d2ef04467c8d09b29741754b51720c4b22e5afbad6dc93e6b481a1f0a916fdc6b729c970259de545c3bbba1e9fa2ee08a2ba52e6c7ba6980d315a8b660b2c2419e93ba8f33995947a4fc4b43e3930fde9f27d6965048ec1b7d4ce164dbd505b28659ec43d84793055896e6182834a2abffc33b9886987b092a426a0807215d641a16597275c82e7d993e1b24eea275e55b1c4eccda102846ea9ec033f5440f802c0903fd887e549457e90c5fcfa45aaa7e9dff260822cd27c013bf751e4e0cab14281d4264a5bddf42a4e15dae6a090dcad95dc4e0ec0a40162ec49b188f2e46eca4aac3574983499dda6f21237871b0785c058ec9552ab23bc410a41bc9ffa8071bdebbc65c3f8fbc3ade026b0a7d8b249852c33cc7c57a226f30253e7975ba385d389fb57047456c73dcbf69acd2acac882e6e9",
    "vault_path": "1",
    "vault_type": "S3Storage",
    "key_id": "9FD5B428F4A90376"
}
```

Take away 16 bytes from full header to get the enc part (or 32 characters from the string)