### PR TITLE
Making the base image smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ You can provision and deploy the different components:
 LocalEGA is divided into several components, whether as docker
 containers or as virtual machines.
 
-| Components | Role |
-|------------|------|
-| db         | A Postgres database with appropriate schema |
-| mq         | A RabbitMQ message broker with appropriate accounts, exchanges, queues and bindings |
-| inbox      | SFTP server, acting as a dropbox, where user credentials come from CentralEGA |
-| keyserver  | Handles the encryption/decryption keys |
-| ingesters  | Split the Crypt4GH header and move the remainder to the storage backend. No cryptographic task, nor connection to the keyserver. |
-| verifiers  | Connect to the keyserver (via SSL) and decrypt the stored files and checksum them against their embedded checksum. |
-| vault      | Storage backend: as a regular file system or as a S3 object store. |
+| Components  | Role |
+|-------------|------|
+| db          | A Postgres database with appropriate schema |
+| mq          | A RabbitMQ message broker with appropriate accounts, exchanges, queues and bindings |
+| inbox       | SFTP server, acting as a dropbox, where user credentials come from CentralEGA |
+| keyserver   | Handles the encryption/decryption keys |
+| ingesters   | Split the Crypt4GH header and move the remainder to the storage backend. No cryptographic task, nor connection to the keyserver. |
+| verifiers   | Connect to the keyserver (via SSL) and decrypt the stored files and checksum them against their embedded checksum. |
+| vault       | Storage backend: as a regular file system or as a S3 object store. |
+| controllers |Plugin-based Quality Controllers, running in the background. store. |
 
 Find the [LocalEGA documentation](http://localega.readthedocs.io) hosted on [ReadTheDocs.org](https://readthedocs.org/).

--- a/deployments/docker/Makefile
+++ b/deployments/docker/Makefile
@@ -12,6 +12,7 @@ private/cega.yml private/lega.yml private bootstrap:
 		    -v ${PWD}:/ega \
 		    -v ${PWD}/../../extras/db.sql:/tmp/db.sql \
 		    -v ${PWD}/../../extras/generate_pgp_key.py:/tmp/generate_pgp_key.py \
+				-v ${PWD}/../../extras/rabbitmq_hash.py:/tmp/rabbitmq_hash.py \
 		    --entrypoint /ega/bootstrap/boot.sh \
 		    nbisweden/ega-base ${ARGS}
 

--- a/deployments/docker/images/Makefile
+++ b/deployments/docker/images/Makefile
@@ -1,7 +1,7 @@
 
 # Add those packages to the containers, in case DEV is defined
 ifdef DEV
-DEV_PACKAGES="nc nmap tcpdump lsof strace bash-completion bash-completion-extras"
+DEV_PACKAGES="nmap tcpdump lsof strace bash-completion bash-completion-extras"
 endif
 
 CHECKOUT=$(shell git rev-parse --abbrev-ref HEAD)

--- a/deployments/docker/images/Makefile
+++ b/deployments/docker/images/Makefile
@@ -1,7 +1,7 @@
 
 # Add those packages to the containers, in case DEV is defined
 ifdef DEV
-DEV_PACKAGES="nss-tools nc nmap tcpdump lsof strace bash-completion bash-completion-extras"
+DEV_PACKAGES="nc nmap tcpdump lsof strace bash-completion bash-completion-extras"
 endif
 
 CHECKOUT=$(shell git rev-parse --abbrev-ref HEAD)

--- a/deployments/docker/images/README.md
+++ b/deployments/docker/images/README.md
@@ -13,17 +13,15 @@ Later on, if the `nbisweden/ega-base` does not need to be recreated, one can typ
 A typical build goes as follows:
 
 	`make base`
-	`make inbox`
 
 ## Results
 
-`rabbitmq:management`, `postgres:latest`, `centos:7.4.1708` are pulled from the main Docker hub.
+`rabbitmq:management`, `postgres:latest`, `centos:7.4.1708`, `nbisweden/ega-mina-inbox` are pulled from the main Docker hub.
 
 The following images are created locally:
 
 | Repository | Tag      | Role |
 |------------|:--------:|------|
-| nbisweden/ega-inbox    | <HEAD commit> or latest | SFTP server on top of `nbisweden/ega-base:latest` |
 | nbisweden/ega-base   | <HEAD commit> or latest | Base Image for all services including python 3.6.1 |
 
 

--- a/deployments/docker/images/base/Dockerfile
+++ b/deployments/docker/images/base/Dockerfile
@@ -5,14 +5,19 @@ ARG DEV_PACKAGES=
 RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm && \
     yum -y install epel-release && \
     yum -y update && \
-    yum -y install git gcc make bzip2 curl vim-common \
+    yum -y install git make bzip2 curl vim-common \
                    zlib-devel bzip2-devel unzip \
                    openssh-server openssl \
 		   wget dpkg \
-		   pam-devel libcurl-devel jq-devel fuse fuse-libs cronie \
+		   cronie \
 		   python36u python36u-pip ${DEV_PACKAGES}
 
 RUN [[ -e /lib64/libpython3.6m.so ]] || ln -s /lib64/libpython3.6m.so.1.0 /lib64/libpython3.6m.so
+
+# Add Tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
 
 ENV GOSU_VERSION 1.10
 ENV GPG_KEYS B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/deployments/docker/images/base/Dockerfile
+++ b/deployments/docker/images/base/Dockerfile
@@ -5,7 +5,7 @@ ARG DEV_PACKAGES=
 RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm && \
     yum -y install epel-release && \
     yum -y update && \
-    yum -y install git make bzip2 curl vim-common \
+    yum -y install git make bzip2 curl \
                    zlib-devel bzip2-devel unzip \
                    openssh-server openssl \
 		   wget dpkg \

--- a/deployments/docker/images/base/Dockerfile
+++ b/deployments/docker/images/base/Dockerfile
@@ -5,7 +5,7 @@ ARG DEV_PACKAGES=
 RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm && \
     yum -y install epel-release && \
     yum -y update && \
-    yum -y install git make bzip2 curl \
+    yum -y install git make bzip2 curl vim-common \
                    zlib-devel bzip2-devel unzip \
                    openssh-server openssl \
 		   wget dpkg \
@@ -27,9 +27,9 @@ RUN set -ex && \
 
 # verify the signature
 RUN export GNUPGHOME="$(mktemp -d)" && \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEYS" \
+    (gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEYS" \
     || gpg --keyserver pgp.mit.edu --recv-keys "$GPG_KEYS" \
-    || gpg --keyserver keyserver.pgp.com --recv-keys "$GPG_KEYS" && \
+    || gpg --keyserver keyserver.pgp.com --recv-keys "$GPG_KEYS") && \
     gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys  && \
     gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu && \
     rm -r "$GNUPGHOME" /tmp/gosu.asc && \

--- a/deployments/docker/images/base/Dockerfile
+++ b/deployments/docker/images/base/Dockerfile
@@ -5,11 +5,10 @@ ARG DEV_PACKAGES=
 RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm && \
     yum -y install epel-release && \
     yum -y update && \
-    yum -y install git make bzip2 curl vim-common \
+    yum -y install git make bzip2 curl \
                    zlib-devel bzip2-devel unzip \
                    openssh-server openssl \
 		   wget dpkg \
-		   cronie \
 		   python36u python36u-pip ${DEV_PACKAGES}
 
 RUN [[ -e /lib64/libpython3.6m.so ]] || ln -s /lib64/libpython3.6m.so.1.0 /lib64/libpython3.6m.so

--- a/extras/rabbitmq_hash.py
+++ b/extras/rabbitmq_hash.py
@@ -1,0 +1,41 @@
+from base64 import b64encode
+import os
+import hashlib
+import argparse
+
+
+# inspired by https://gist.github.com/komuw/c6fb1a1c757afb43fe69bdd736d5cf63
+def hash_pass(password):
+    """Hashing password according to RabbitMQ specs."""
+    # 1.Generate a random 32 bit salt:
+    # This will generate 32 bits of random data:
+    salt = os.urandom(4)
+
+    # 2.Concatenate that with the UTF-8 representation of the password (in this case "simon")
+    tmp0 = salt + password.encode('utf-8')
+
+    # 3. Take the SHA256 hash and get the bytes back
+    tmp1 = hashlib.sha256(tmp0).digest()
+
+    # 4. Concatenate the salt again:
+    salted_hash = salt + tmp1
+
+    # 5. convert to base64 encoding:
+    pass_hash = b64encode(salted_hash).decode("utf-8")
+
+    return pass_hash
+
+
+def main():
+    """Make magic happen."""
+    parser = argparse.ArgumentParser(description='''Creating public/private PGP keys''')
+
+    parser.add_argument('password', help='PGP user name')
+    args = parser.parse_args()
+
+    password_hash = hash_pass(args.password)
+    print(password_hash)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
With the previous PR https://github.com/NBISweden/LocalEGA/pull/316 we kinda missed to remove some packages (mainly the ones used by inbox), this PR addresses that.
Got the image down to 762MB from 1.01GB.

Added tini https://github.com/krallin/tini as we will use it in some of the containers and its size is negligible. 
