### PR TITLE
Add big (1024MB) file ingestion scenario

### DIFF
--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/CommonTests.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/CommonTests.java
@@ -8,8 +8,8 @@ import org.junit.runner.RunWith;
 @CucumberOptions(
         format = {"pretty", "html:target/cucumber"},
         features = {
-                "src/test/resources/cucumber/features/authentication.feature",
-                "src/test/resources/cucumber/features/uploading.feature",
+//                "src/test/resources/cucumber/features/authentication.feature",
+//                "src/test/resources/cucumber/features/uploading.feature",
                 "src/test/resources/cucumber/features/ingestion.feature"
         }
 )

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/CommonTests.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/CommonTests.java
@@ -8,8 +8,8 @@ import org.junit.runner.RunWith;
 @CucumberOptions(
         format = {"pretty", "html:target/cucumber"},
         features = {
-//                "src/test/resources/cucumber/features/authentication.feature",
-//                "src/test/resources/cucumber/features/uploading.feature",
+                "src/test/resources/cucumber/features/authentication.feature",
+                "src/test/resources/cucumber/features/uploading.feature",
                 "src/test/resources/cucumber/features/ingestion.feature"
         }
 )

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/pojo/FileStatus.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/pojo/FileStatus.java
@@ -1,12 +1,16 @@
 package se.nbis.lega.cucumber.pojo;
 
+import java.util.Arrays;
+
 public enum FileStatus {
 
     RECEIVED("Received"),
     IN_PROGRESS("In progress"),
     COMPLETED("Completed"),
     ARCHIVED("Archived"),
-    ERROR("Error");
+    ERROR("Error"),
+    UNDEFINED("(0 rows)");
+
 
     private final String status;
 
@@ -16,6 +20,10 @@ public enum FileStatus {
 
     public String getStatus() {
         return status;
+    }
+
+    public static FileStatus getValue(String status) {
+        return Arrays.stream(FileStatus.values()).filter(fs -> fs.status.equals(status)).findAny().orElse(FileStatus.UNDEFINED);
     }
 
 }

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/pojo/FileStatus.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/pojo/FileStatus.java
@@ -1,0 +1,21 @@
+package se.nbis.lega.cucumber.pojo;
+
+public enum FileStatus {
+
+    RECEIVED("Received"),
+    IN_PROGRESS("In progress"),
+    COMPLETED("Completed"),
+    ARCHIVED("Archived"),
+    ERROR("Error");
+
+    private final String status;
+
+    FileStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+}

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
@@ -165,7 +165,7 @@ public class Ingestion implements En {
                 Thread.sleep(1000);
                 timeout += 1000;
                 if (timeout > maxTimeout) {
-                    throw new TimeoutException(String.format("Ingestion didn't complete in time: ingest.max-timeout = %s", timeout));
+                    throw new TimeoutException(String.format("Ingestion didn't complete in time: ingest.max-timeout = %s", maxTimeout));
                 }
             }
             // And we sleep one more second for entry to be updated in the database.

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Ingestion.java
@@ -50,10 +50,10 @@ public class Ingestion implements En {
         When("^I turn on the database", () -> utils.startContainer(utils.findContainer(utils.getProperty("images.name.db"),
                 utils.getProperty("container.name.db"))));
 
-        When("^I turn off RabbitMQ broker", () -> utils.stopContainer(utils.findContainer(utils.getProperty("images.name.mq"),
+        When("^I turn off the message broker", () -> utils.stopContainer(utils.findContainer(utils.getProperty("images.name.mq"),
                 utils.getProperty("container.name.mq"))));
 
-        When("^I turn on RabbitMQ broker", () -> utils.startContainer(utils.findContainer(utils.getProperty("images.name.mq"),
+        When("^I turn on the message broker", () -> utils.startContainer(utils.findContainer(utils.getProperty("images.name.mq"),
                 utils.getProperty("container.name.mq"))));
 
         When("^I ingest file from the LocalEGA inbox$", () -> {

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Robustness.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Robustness.java
@@ -2,16 +2,8 @@ package se.nbis.lega.cucumber.steps;
 
 import cucumber.api.java8.En;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
 import se.nbis.lega.cucumber.Context;
 import se.nbis.lega.cucumber.Utils;
-
-import javax.crypto.Cipher;
-import javax.crypto.KeyGenerator;
-import javax.crypto.SecretKey;
-import java.io.File;
-import java.io.RandomAccessFile;
 
 @Slf4j
 public class Robustness implements En {
@@ -20,28 +12,6 @@ public class Robustness implements En {
         Utils utils = context.getUtils();
 
         When("^the system is restarted$", utils::restartAllLocalEGAContainers);
-
-        // TODO: Don't load large file in memory - stream it
-        Given("^I have a big file encrypted with Crypt4GH using a LocalEGA's pubic key$", () -> {
-            try {
-                File rawFile = context.getRawFile();
-                try (RandomAccessFile randomAccessFile = new RandomAccessFile(rawFile, "rw")) {
-                    randomAccessFile.setLength(1024 * 1024 * 10);
-                }
-                KeyGenerator keygenerator = KeyGenerator.getInstance("DES");
-                SecretKey desKey = keygenerator.generateKey();
-                Cipher desCipher = Cipher.getInstance("DES");
-                desCipher.init(Cipher.ENCRYPT_MODE, desKey);
-                byte[] encryptedContents = desCipher.doFinal(FileUtils.readFileToByteArray(rawFile));
-                File encryptedFile = new File(rawFile.getAbsolutePath() + ".enc");
-                FileUtils.writeByteArrayToFile(encryptedFile, encryptedContents);
-                context.setEncryptedFile(encryptedFile);
-            } catch (Exception e) {
-                log.error(e.getMessage(), e);
-                Assert.fail(e.getMessage());
-            }
-        });
-
     }
 
 }

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Uploading.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Uploading.java
@@ -25,7 +25,6 @@ public class Uploading implements En {
     public Uploading(Context context) {
         Utils utils = context.getUtils();
 
-        // TODO: Don't load large file in memory - stream it
         Given("^I have a ([^\"]*) MB file encrypted with Crypt4GH using a LocalEGA's pubic key$", (String fileSize) -> {
             try {
                 int size = Integer.parseInt(fileSize);

--- a/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Uploading.java
+++ b/deployments/docker/tests/src/test/java/se/nbis/lega/cucumber/steps/Uploading.java
@@ -14,6 +14,7 @@ import javax.crypto.*;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -24,10 +25,15 @@ public class Uploading implements En {
     public Uploading(Context context) {
         Utils utils = context.getUtils();
 
-        Given("^I have a file encrypted with Crypt4GH using a LocalEGA's pubic key$", () -> {
-            File rawFile = context.getRawFile();
-            File encryptedFile = new File(rawFile.getAbsolutePath() + ".enc");
+        // TODO: Don't load large file in memory - stream it
+        Given("^I have a ([^\"]*) MB file encrypted with Crypt4GH using a LocalEGA's pubic key$", (String fileSize) -> {
             try {
+                int size = Integer.parseInt(fileSize);
+                File rawFile = context.getRawFile();
+                try (RandomAccessFile randomAccessFile = new RandomAccessFile(rawFile, "rw")) {
+                    randomAccessFile.setLength(1024 * 1024 * size);
+                }
+                File encryptedFile = new File(rawFile.getAbsolutePath() + ".enc");
                 byte[] digest = DigestUtils.sha256(FileUtils.openInputStream(rawFile));
                 String key = FileUtils.readFileToString(new File(String.format("%s/%s/pgp/ega.pub", utils.getPrivateFolderPath(), utils.getProperty("instance.name"))), Charset.defaultCharset());
                 FileOutputStream fileOutputStream = new FileOutputStream(encryptedFile);

--- a/deployments/docker/tests/src/test/resources/config.properties
+++ b/deployments/docker/tests/src/test/resources/config.properties
@@ -2,7 +2,7 @@ private.folder.name = /private
 instance.name = lega
 trace.file.name = .trace
 inbox.folder.path = /ega/inbox
-ingest.max-timeout = 60000
+ingest.max-timeout = 100000
 
 images.name.db = postgres:latest
 images.name.inbox = nbisweden/ega-mina-inbox

--- a/deployments/docker/tests/src/test/resources/config.properties
+++ b/deployments/docker/tests/src/test/resources/config.properties
@@ -2,7 +2,7 @@ private.folder.name = /private
 instance.name = lega
 trace.file.name = .trace
 inbox.folder.path = /ega/inbox
-ingest.max-timeout = 10000
+ingest.max-timeout = 60000
 
 images.name.db = postgres:latest
 images.name.inbox = nbisweden/ega-mina-inbox

--- a/deployments/docker/tests/src/test/resources/cucumber/features/authentication.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/authentication.feature
@@ -19,13 +19,3 @@ Feature: Authentication
     Then authentication fails
 
 #  TODO: Add cache expiry scenario.
-
-#  Scenario: A.3 User exists in Central EGA and tries to connect to LocalEGA, but the inbox was not created for him
-#    Given I have an account at Central EGA
-#    And I have correct private key
-#    And I connect to the LocalEGA inbox via SFTP using private key
-#    And I disconnect from the LocalEGA inbox
-#    And inbox is deleted for my user
-#    When I connect to the LocalEGA inbox via SFTP using private key
-#    Then authentication fails
-

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -23,18 +23,6 @@ Feature: Ingestion
     When I retrieve ingestion information
     Then the ingestion status is "Error"
 
-#  Scenario: I.3 User ingests file encrypted with Crypt4GH, but inbox is not created
-#    Given I have an account at Central EGA
-#    And I have correct private key
-#    And I connect to the LocalEGA inbox via SFTP using private key
-#    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
-#    And I upload encrypted file to the LocalEGA inbox via SFTP
-#    And I have CEGA MQ username and password
-#    And inbox is deleted for my user
-#    And I ingest file from the LocalEGA inbox
-#    When I retrieve ingestion information
-#    Then the ingestion status is "Error"
-
   Scenario: I.2 User ingests file encrypted with Crypt4GH, but file was not found in the inbox
     Given I have an account at Central EGA
     And I have correct private key
@@ -60,16 +48,16 @@ Feature: Ingestion
     When I retrieve ingestion information
     Then the ingestion status is "Error"
 
-  Scenario: I.4 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the vault listener is down
+  Scenario: I.4 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the RabbitMQ broker is down
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
     And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
-    And I turn off the vault listener
+    And I turn off RabbitMQ broker
     And I ingest file from the LocalEGA inbox
-    And I turn on the vault listener
+    And I turn on RabbitMQ broker
     When I retrieve ingestion information
     Then the ingestion status is "NoEntry"
 

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -48,16 +48,16 @@ Feature: Ingestion
     When I retrieve ingestion information
     Then the ingestion status is "Error"
 
-  Scenario: I.4 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the RabbitMQ broker is down
+  Scenario: I.4 User ingests file encrypted with Crypt4GH using a correct key and checksums, but the message broker is down
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
     And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
-    And I turn off RabbitMQ broker
+    And I turn off the message broker
     And I ingest file from the LocalEGA inbox
-    And I turn on RabbitMQ broker
+    And I turn on the message broker
     When I retrieve ingestion information
     Then the ingestion status is "NoEntry"
 

--- a/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/ingestion.feature
@@ -5,7 +5,7 @@ Feature: Ingestion
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
     And I ingest file from the LocalEGA inbox
@@ -39,7 +39,7 @@ Feature: Ingestion
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
     And file is removed from the inbox
@@ -51,7 +51,7 @@ Feature: Ingestion
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
     And I turn off the keyserver
@@ -64,7 +64,7 @@ Feature: Ingestion
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
     And I turn off the vault listener
@@ -77,7 +77,7 @@ Feature: Ingestion
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
     And I turn off the database

--- a/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
@@ -13,7 +13,7 @@ Feature: Robustness
     When I retrieve ingestion information
     Then the ingestion status is "Completed"
 
-  Scenario: R.1 User ingests file encrypted with Crypt4GH using a correct key
+  Scenario: R.1 User ingests big file encrypted with Crypt4GH using a correct key
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key

--- a/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
@@ -1,17 +1,17 @@
 Feature: Robustness
   As a user I want the system to be robust and fault-tolerant
 
-  Scenario: R.0 User ingests file encrypted with Crypt4GH using a correct key and providing checksums as companion files after full system restart
-    Given I have an account at Central EGA
-    And I have correct private key
-    And the system is restarted
-    And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
-    And I upload encrypted file to the LocalEGA inbox via SFTP
-    And I have CEGA MQ username and password
-    And I ingest file from the LocalEGA inbox
-    When I retrieve ingestion information
-    Then the ingestion status is "Completed"
+#  Scenario: R.0 User ingests file encrypted with Crypt4GH using a correct key and providing checksums as companion files after full system restart
+#    Given I have an account at Central EGA
+#    And I have correct private key
+#    And the system is restarted
+#    And I connect to the LocalEGA inbox via SFTP using private key
+#    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
+#    And I upload encrypted file to the LocalEGA inbox via SFTP
+#    And I have CEGA MQ username and password
+#    And I ingest file from the LocalEGA inbox
+#    When I retrieve ingestion information
+#    Then the ingestion status is "Completed"
 
 #  TODO: Implement "big file" and "many files" scenarios.
 
@@ -19,7 +19,7 @@ Feature: Robustness
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a 100 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1024 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
     And I ingest file from the LocalEGA inbox

--- a/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
@@ -1,19 +1,17 @@
 Feature: Robustness
   As a user I want the system to be robust and fault-tolerant
 
-#  Scenario: R.0 User ingests file encrypted with Crypt4GH using a correct key and providing checksums as companion files after full system restart
-#    Given I have an account at Central EGA
-#    And I have correct private key
-#    And the system is restarted
-#    And I connect to the LocalEGA inbox via SFTP using private key
-#    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
-#    And I upload encrypted file to the LocalEGA inbox via SFTP
-#    And I have CEGA MQ username and password
-#    And I ingest file from the LocalEGA inbox
-#    When I retrieve ingestion information
-#    Then the ingestion status is "Completed"
-
-#  TODO: Implement "big file" and "many files" scenarios.
+  Scenario: R.0 User ingests file encrypted with Crypt4GH using a correct key and providing checksums as companion files after full system restart
+    Given I have an account at Central EGA
+    And I have correct private key
+    And the system is restarted
+    And I connect to the LocalEGA inbox via SFTP using private key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I upload encrypted file to the LocalEGA inbox via SFTP
+    And I have CEGA MQ username and password
+    And I ingest file from the LocalEGA inbox
+    When I retrieve ingestion information
+    Then the ingestion status is "Completed"
 
   Scenario: R.1 User ingests file encrypted with Crypt4GH using a correct key
     Given I have an account at Central EGA

--- a/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/robustness.feature
@@ -6,7 +6,7 @@ Feature: Robustness
     And I have correct private key
     And the system is restarted
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     And I upload encrypted file to the LocalEGA inbox via SFTP
     And I have CEGA MQ username and password
     And I ingest file from the LocalEGA inbox
@@ -15,13 +15,13 @@ Feature: Robustness
 
 #  TODO: Implement "big file" and "many files" scenarios.
 
-#  Scenario: R.2 User ingests a big file encrypted with Crypt4GH using a correct key and providing checksums as companion files
-#    Given I have an account at Central EGA
-#    And I have correct private key
-#    And I connect to the LocalEGA inbox via SFTP using private key
-#    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
-#    And I upload encrypted file to the LocalEGA inbox via SFTP
-#    And I have CEGA MQ username and password
-#    And I ingest file from the LocalEGA inbox
-#    When I retrieve ingestion information
-#    Then the ingestion status is "Archived"
+  Scenario: R.1 User ingests file encrypted with Crypt4GH using a correct key
+    Given I have an account at Central EGA
+    And I have correct private key
+    And I connect to the LocalEGA inbox via SFTP using private key
+    And I have a 100 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I upload encrypted file to the LocalEGA inbox via SFTP
+    And I have CEGA MQ username and password
+    And I ingest file from the LocalEGA inbox
+    When I retrieve ingestion information
+    Then the ingestion status is "Completed"

--- a/deployments/docker/tests/src/test/resources/cucumber/features/uploading.feature
+++ b/deployments/docker/tests/src/test/resources/cucumber/features/uploading.feature
@@ -5,6 +5,6 @@ Feature: Uploading
     Given I have an account at Central EGA
     And I have correct private key
     And I connect to the LocalEGA inbox via SFTP using private key
-    And I have a file encrypted with Crypt4GH using a LocalEGA's pubic key
+    And I have a 1 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
     When I upload encrypted file to the LocalEGA inbox via SFTP
     Then the file is uploaded successfully


### PR DESCRIPTION
```gherkin
  Scenario: R.1 User ingests big file encrypted with Crypt4GH using a correct key
    Given I have an account at Central EGA
    And I have correct private key
    And I connect to the LocalEGA inbox via SFTP using private key
    And I have a 1024 MB file encrypted with Crypt4GH using a LocalEGA's pubic key
    And I upload encrypted file to the LocalEGA inbox via SFTP
    And I have CEGA MQ username and password
    And I ingest file from the LocalEGA inbox
    When I retrieve ingestion information
    Then the ingestion status is "Completed"
```

The file size is configurable. 