### PR TITLE
Fixing warning from GitHub

### DIFF
--- a/deployments/docker/tests/pom.xml
+++ b/deployments/docker/tests/pom.xml
@@ -110,8 +110,8 @@
 
     <repositories>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://github.com/uio-bmi/crypt4gh/raw/maven</url>
+            <id>nexus.norgene.no</id>
+            <url>https://nexus.norgene.no/repository/maven-releases/</url>
         </repository>
     </repositories>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.0.7
 aiohttp-jinja2==0.13.0
 fusepy
 sphinx_rtd_theme
-cryptography==2.2.2
+cryptography==2.3
 pgpy
 psycopg2-binary==2.7.4
 aiopg==0.13.0


### PR DESCRIPTION
Easier than I thought: I just upgraded the cryptography package.