### PR TITLE
Update the database with the header before copying

### DIFF
--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -77,14 +77,16 @@ def work(fs, channel, data):
         LOG.debug(f'Reading header | file_id: {file_id}')
         beginning, header = get_header(infile)
 
+        header_hex = (beginning+header).hex()
+        data['header'] = header_hex
+        db.store_header(file_id, header_hex) # header bytes will be .hex()
+
         target = fs.location(file_id)
         LOG.info(f'[{fs.__class__.__name__}] Moving the rest of {filepath} to {target}')
         target_size = fs.copy(infile, target) # It will copy the rest only
 
         LOG.info(f'Vault copying completed. Updating database')
-        header_hex = (beginning+header).hex()
-        db.set_info(file_id, target, target_size, header_hex) # header bytes will be .hex()
-        data['header'] = header_hex
+        db.set_archived(file_id, target, target_size)
         data['vault_path'] = target
 
     LOG.debug(f"Reply message: {data}")

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -195,7 +195,7 @@ def set_archived(file_id, vault_path, vault_filesize):
     """Archive ``file_id``."""
     assert file_id, 'Eh? No file_id?'
     assert vault_path, 'Eh? No vault name?'
-    LOG.debug(f'Setting status to arhived for file_id {file_id}')
+    LOG.debug(f'Setting status to archived for file_id {file_id}')
     with connect() as conn:
         with conn.cursor() as cur:
             cur.execute('UPDATE files '

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -175,24 +175,38 @@ def set_stable_id(file_id, stable_id):
                          'file_id': file_id,
                          'stable_id': stable_id })
 
-def set_info(file_id, vault_path, vault_filesize, header):
-    """Updating information in database for ``file_id``."""
+
+def store_header(file_id, header):
+    """Store header for ``file_id``."""
+    assert file_id, 'Eh? No file_id?'
+    assert header, 'Eh? No header?'
+    LOG.debug(f'Store header for file_id {file_id}')
+    with connect() as conn:
+        with conn.cursor() as cur:
+            cur.execute('UPDATE files '
+                        'SET header = %(header)s '
+                        'WHERE id = %(file_id)s;',
+                        {'file_id': file_id,
+                         'header': header,
+                        })
+
+
+def set_archived(file_id, vault_path, vault_filesize):
+    """Archive ``file_id``."""
     assert file_id, 'Eh? No file_id?'
     assert vault_path, 'Eh? No vault name?'
-    LOG.debug(f'Updating status file_id {file_id}')
+    LOG.debug(f'Setting status to arhived for file_id {file_id}')
     with connect() as conn:
         with conn.cursor() as cur:
             cur.execute('UPDATE files '
                         'SET status = %(status)s, '
                         '    vault_path = %(vault_path)s, '
-                        '    vault_filesize = %(vault_filesize)s, '
-                        '    header = %(header)s '
+                        '    vault_filesize = %(vault_filesize)s '
                         'WHERE id = %(file_id)s;',
                         {'status': 'Archived',
                          'file_id': file_id,
                          'vault_path': vault_path,
-                         'vault_filesize': vault_filesize,
-                         'header': header,
+                         'vault_filesize': vault_filesize
                         })
 
 ######################################

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,7 +1,8 @@
 import unittest
 from lega.utils.db import (insert_file,
                            get_errors, set_error,
-                           get_info, set_info,
+                           get_info,
+                           store_header, set_archived,
                            mark_in_progress, mark_completed,
                            set_stable_id,
                            fetch_args, connect)
@@ -68,10 +69,17 @@ class DBTest(unittest.TestCase):
         mock_connect().__enter__().cursor().__enter__().execute.assert_called()
 
     @mock.patch('lega.utils.db.connect')
-    def test_set_info(self, mock_connect):
+    def test_store_header(self, mock_connect):
         """DB set progress."""
         # Values are not important in this call
-        set_info("file_id", '/ega/vault/000/000/0a1', 1000, b'header')
+        store_header("file_id", b'header')
+        mock_connect().__enter__().cursor().__enter__().execute.assert_called()
+
+    @mock.patch('lega.utils.db.connect')
+    def test_set_archived(self, mock_connect):
+        """DB set progress."""
+        # Values are not important in this call
+        set_archived("file_id", '/ega/vault/000/000/0a1', 1000)
         mock_connect().__enter__().cursor().__enter__().execute.assert_called()
 
     @mock.patch('lega.utils.db.connect')


### PR DESCRIPTION
Previous logic:

1. Read header of file
2. Copy file without header to the Storage
3. Save header information and update status of file in database.

New proposed logic:

1. Read header of file
2. Store header in database.
3. Copy file without header to Storage
4. Update status of file in database.

This is to guarantee that we won't end up in a situation where the file has been copied without the header but the header is not in the database. This can theoretically happen if the database update fails forsome reason.