### PR TITLE
Add image build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ services: docker
 stages:
   - name: unit tests
     if: type IN (push, pull_request)
+  - name: image build
+    if: type IN (pull_request)
   - name: integration tests
     if: type IN (pull_request)
 
@@ -26,6 +28,14 @@ jobs:
         - pip install tox-travis
       # command to run tests
       script: tox
+    - stage: image build
+      before_script:
+        - cd docker
+      script:
+        - make -C images all
+        - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+        - docker push nbisweden/ega-base:dev
+        - docker push nbisweden/ega-inbox:dev
     - stage: integration tests
       before_script:
         - cd docker
@@ -66,6 +76,17 @@ jobs:
         - make -C test
         - sleep 10
         - make -C test check
+
+after_success:
+  - if [[ "$TRAVIS_BRANCH" == "dev" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+      docker pull nbisweden/ega-base:dev ;
+      docker pull nbisweden/ega-inbox:dev ;
+      docker tag nbisweden/ega-base:dev nbisweden/ega-base:latest ;
+      docker tag nbisweden/ega-inbox:dev nbisweden/ega-inbox:latest ;
+      docker push nbisweden/ega-base:latest ;
+      docker push nbisweden/ega-inbox:latest ;
+    fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       before_script:
         - cd docker
       script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
         - make -C images all
         - docker push nbisweden/ega-base:dev
         - docker push nbisweden/ega-inbox:dev
@@ -79,7 +79,7 @@ jobs:
 
 after_success:
   - if [[ "$TRAVIS_BRANCH" == "dev" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ;
+      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin ;
       docker pull nbisweden/ega-base:dev ;
       docker pull nbisweden/ega-inbox:dev ;
       docker tag nbisweden/ega-base:dev nbisweden/ega-base:latest ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
       before_script:
         - cd docker
       script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - make -C images all
-        - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
         - docker push nbisweden/ega-base:dev
         - docker push nbisweden/ega-inbox:dev
     - stage: integration tests
@@ -79,7 +79,7 @@ jobs:
 
 after_success:
   - if [[ "$TRAVIS_BRANCH" == "dev" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ;
       docker pull nbisweden/ega-base:dev ;
       docker pull nbisweden/ega-inbox:dev ;
       docker tag nbisweden/ega-base:dev nbisweden/ega-base:latest ;

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -16,7 +16,7 @@ private/cega.yml private/lega.yml private bootstrap:
 		    -v ${PWD}/../extras/generate_pgp_key.py:/tmp/generate_pgp_key.py \
 		    -v ${PWD}/../extras/rabbitmq_hash.py:/tmp/rabbitmq_hash.py \
 		    --entrypoint /ega/bootstrap/boot.sh \
-		    nbisweden/ega-base ${ARGS}
+		    nbisweden/ega-base:dev ${ARGS}
 
 network:
 	@docker network inspect cega &>/dev/null || docker network create cega &>/dev/null

--- a/docker/bootstrap/cega.sh
+++ b/docker/bootstrap/cega.sh
@@ -171,7 +171,7 @@ services:
 
   cega-users:
     env_file: cega/env
-    image: nbisweden/ega-base
+    image: nbisweden/ega-base:dev
     hostname: cega-users
     container_name: cega-users
     #ports:
@@ -197,7 +197,7 @@ services:
     #  - "8761:8761"
     expose:
       - 8761
-    image: nbisweden/ega-base
+    image: nbisweden/ega-base:dev
     container_name: cega-eureka
     volumes:
       - ../images/cega/eureka.py:/cega/eureka.py

--- a/docker/bootstrap/lega.sh
+++ b/docker/bootstrap/lega.sh
@@ -188,7 +188,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF  # SFTP inbox
       - CEGA_ENDPOINT_JSON_PREFIX=
     ports:
       - "${DOCKER_PORT_inbox}:9000"
-    image: nbisweden/ega-inbox
+    image: nbisweden/ega-inbox:dev
     volumes:
       - ./lega/conf.ini:/etc/ega/conf.ini:ro
       - inbox:/ega/inbox
@@ -201,7 +201,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     depends_on:
       - db
       - mq
-    image: nbisweden/ega-base
+    image: nbisweden/ega-base:dev
     container_name: id-mapper
     volumes:
        - ./lega/conf.ini:/etc/ega/conf.ini:ro
@@ -215,7 +215,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
     depends_on:
       - db
       - mq
-    image: nbisweden/ega-base
+    image: nbisweden/ega-base:dev
     container_name: ingest
     environment:
       - S3_ACCESS_KEY=${S3_ACCESS_KEY}
@@ -234,7 +234,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
   keys:
     hostname: keys
     container_name: keys
-    image: nbisweden/ega-base
+    image: nbisweden/ega-base:dev
     expose:
       - "8443"
     environment:
@@ -263,7 +263,7 @@ cat >> ${PRIVATE}/lega.yml <<EOF
       - keys
     hostname: verify
     container_name: verify
-    image: nbisweden/ega-base
+    image: nbisweden/ega-base:dev
     environment:
       - LEGA_PASSWORD=${LEGA_PASSWORD}
       - S3_ACCESS_KEY=${S3_ACCESS_KEY}

--- a/docker/images/Makefile
+++ b/docker/images/Makefile
@@ -28,6 +28,7 @@ base inbox:
 	docker build ${BUILD_ARGS} \
                      --cache-from $(TARGET_PREFIX)-$@:latest \
                      --tag $(TARGET_PREFIX)-$@:$(TAG) \
+										 --tag $(TARGET_PREFIX)-$@:dev \
                      --tag $(TARGET_PREFIX)-$@:latest \
                      $@
 

--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -16,24 +16,24 @@ A typical build goes as follows:
 
 ## Results
 
-`rabbitmq:management`, `postgres:latest`, `centos:7.4.1708` are pulled from the main Docker hub.
+`rabbitmq:management`, `postgres:9.6`, `centos:7.4.1708` are pulled from the main Docker hub.
 
 The following images are created locally:
 
 | Repository | Tag      | Role |
 |------------|:--------:|------|
-| nbisweden/ega-inbox  | <HEAD commit> or latest | SFTP server on top of `nbisweden/ega-base:latest` |
-| nbisweden/ega-base   | <HEAD commit> or latest | Base Image for all services including python 3.6.1 |
+| nbisweden/ega-inbox  | `<HEAD commit>`, `latest` or `dev`  | SFTP server on top of `nbisweden/ega-base` |
+| nbisweden/ega-base   | `<HEAD commit>`, `latest` or `dev` | Base Image for all services including python 3.6.1 |
 
 
 We also use 2 stubbing services in order to fake the necessary Central EGA components
 
 | Repository | Tag      | Role |
 |------------|:--------:|------|
-| cega-users | <HEAD commit> or latest | Sets up a postgres database with appropriate tables |
-| cega-mq | <HEAD commit> or latest | Sets up a RabbitMQ message broker with appropriate accounts, exchanges, queues and bindings |
-| cega-eureka | <HEAD commit> or latest | Sets up a fake Eureka service discovery server in order to make the LocalEGA Keyserver register |
+| cega-users | `<HEAD commit>` , `latest` or `dev` | Sets up a postgres database with appropriate tables, on top of `nbisweden/ega-base` |
+| cega-mq | `rabbitmq:3.6.14-management` | Sets up a RabbitMQ message broker with appropriate accounts, exchanges, queues and bindings |
+| cega-eureka | `<HEAD commit>`, `latest` or `dev` | Sets up a fake Eureka service discovery server in order to make the LocalEGA Keyserver register, on top of `nbisweden/ega-base` |
 
 ## Logging
 
-We also make use of ELK stack for logging thus the `elasticsearch-oss` `logstash-oss` and `kibana-oss` will be pulled from Docker hub.
+ELK stack can be added as a logging solution using the `elasticsearch-oss` `logstash-oss` and `kibana-oss`. This requires adding the images to the `docker-compose` YML.

--- a/docker/tests/src/test/resources/config.properties
+++ b/docker/tests/src/test/resources/config.properties
@@ -6,11 +6,11 @@ ingest.max-timeout = 100000
 
 images.name.db = postgres:9.6
 images.name.inbox = nbisweden/ega-mina-inbox
-images.name.ingest = nbisweden/ega-base
-images.name.keys = nbisweden/ega-base
+images.name.ingest = nbisweden/ega-base:dev
+images.name.keys = nbisweden/ega-base:dev
 images.name.mq = rabbitmq:3.6.14-management
 images.name.s3 = minio/minio
-images.name.verify = nbisweden/ega-base
+images.name.verify = nbisweden/ega-base:dev
 
 container.name.db = db
 container.name.inbox = inbox


### PR DESCRIPTION
We would like to add image build to the our CI/CD workflow. The reason for this is to replace the need to build the image locally (on each developer machine) and push the to docker hub every time we do a new PR or a new change to the source code.
How do we approach this issue is exemplified in the image:

![image](https://user-images.githubusercontent.com/47524/45405087-2c404c00-b66a-11e8-95d9-b5c106ac364c.png)

We do introduce a `dev` tag to the image that we use for running the tests that we push to docker hub. We do this once because the stages are run in parallel and to avoid building the image multiple times (stages do not share resources e.g. images, from what Travis is saying) .

> I know a better/another way to do this.

Open to suggestions and improvements.

> Why do we have in the docker compose the `dev` tag instead of the latest. Does that mean whoever uses the docker-compose will not have the `latest` image?

Fair point. We could add a flag that specifies, if one is developing or deploying, but then again we do have other deployment options and the `dev` tag and `latest` are to a certain degree in sync.

> I see other changes here.

Yes, this was branched from: `feature/ingest-store-header-early` (~we expect that PR to be merged first~).

> Why does it take so long to build the image?

Maybe it is a few minutes slower compared to when building it locally, but it is worth not dealing with the hassle (personal opinion).
The one that takes some time is the `ega-inbox`, and yes we need it as we supporting it. It would be a nice idea to build the image for it in a different repo as we do for Apache Mina Inbox, but this is not the scope of this issue.
