### PR TITLE
filepath, filename gets correctly set in send_message

### DIFF
--- a/lega/notifications.py
+++ b/lega/notifications.py
@@ -75,12 +75,14 @@ class Forwarder(asyncio.Protocol):
             except Exception as e:
                 LOG.error("Error notifying upload: %s", e)
 
-    def send_message(self, username, filename):
+    def send_message(self, username, path):
         """Publish message to message broker that a file was added to inbox."""
         inbox = self.inbox_location % username
-        filepath, filename = (filename, filename[len(inbox):])
+
         if self.isolation:
-            filepath, filename = (os.path.join(inbox, filename.lstrip('/')), filename)
+            filepath, filename = (os.path.join(inbox, path.lstrip('/')), path)
+        else:
+            filepath, filename = (path, path[len(inbox):])
 
         LOG.debug("Filepath %s", filepath)
         msg = {'user': username,


### PR DESCRIPTION
filepath, filename gets correctly set in send_message

Also updated the names of the parameters so that they don't get
overwritten by the function body - this reduces the amount of state one
has to keep track of when reading and/or updating the function.

### Describe the pull request:
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
1. `notifications.py` - fixed bug according to above

### Steps to reproduce the original issue

1. Checkout `1f9d197` and make sure that all docker images are built against that revision
2. Set `log = console` in `private/lega/conf.ini`
3. run `docker-compose up`
4. run `make upload` in a different terminal inside the `docker/test` directory

The (relevant) log output from docker-compose will be:

```
inbox          | [lega.notifications][ INFO ] (L41) Using chroot isolation
inbox          | [lega.notifications][ INFO ] (L73) User ega-box-999 uploaded /file.txt.c4ga
inbox          | [lega.utils.checksum][ERROR ] (L43) Unable to calculate checksum: IsADirectoryError(21, 'Is a directory')
inbox          | Received disconnect from 192.168.240.1 port 54852:11: disconnected by user
inbox          | Disconnected from user ega-box-999 192.168.240.1 port 54852
```